### PR TITLE
Dbus taskswitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ We provide logging through [Qt's logging framework](https://doc.qt.io/qt-5/qlogg
 
 The compositor implements a couple of DBus interfaces to provide system/window manager services. They are exposed under the compositor service name `com.basyskom.embeddedcompositor`:
 
-* /taskswitcher (com.embeddedcompositor.taskswitcher) - allows the task switcher to be opened or closed from e.g. a menu button.
+* /taskswitcher (com.embeddedcompositor.taskswitcher) - allows the task switcher to be opened or closed from e.g. a menu button. Provides List of currently active views (/taskswitcher/views) and allows currently active view to be queried and set (taskswitcher/currentView). Views are identified by a GUID and the list of surfaces includes process id and view label for convenience.
 * /globaloverlay (com.embeddedcompositor.globaloverlay) - displays a global overlay hiding all other UI elements for a boot or shutdown message.
 * /screen (com.embeddedcompositor.screen) - control screen orientation via the orientation property. allowed values: "0", "90", "180", "270"
 

--- a/dbus/com.embeddedcompositor.taskswitcher.xml
+++ b/dbus/com.embeddedcompositor.taskswitcher.xml
@@ -5,6 +5,9 @@
 
 <method name="Open"/>
 <method name="Close"/>
-
+<property name="currentView" type="s" access="readwrite"/>
+<property name="views" type="a(ssu)"  access="read" >
+    <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
+</property>
 </interface>
 </node>

--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -9,7 +9,7 @@ if [ $(arch) = "armv7l" ]; then
 else
     echo "running on dev host"
     export $(dbus-launch)
-    #qdbusviewer &
+    qdbusviewer &
     BUILD_ROOT=/home/florian/basyskom/build-compositor-Desktop-Debug
 	export QT_ENABLE_HIGHDPI_SCALING=0
 	export QT_SCREEN_SCALE_FACTORS=

--- a/dev-tools/testclients/bottomclient/bottomclient.pro
+++ b/dev-tools/testclients/bottomclient/bottomclient.pro
@@ -7,6 +7,7 @@ RESOURCES += qml.qrc
 
 include(../common.pri)
 
+QDBUSXML2CPP_INTERFACE_HEADER_FLAGS = -i $$top_srcdir/embedded-compositor/dbusinterface.h
 DBUS_INTERFACES += \
     $$top_srcdir/dbus/com.embeddedcompositor.globaloverlay.xml \
     $$top_srcdir/dbus/com.embeddedcompositor.screen.xml \

--- a/embedded-compositor/dbusinterface.cpp
+++ b/embedded-compositor/dbusinterface.cpp
@@ -2,118 +2,107 @@
 
 #include "dbusinterface.h"
 #include "dbus-selector.h"
-#include <QDBusConnection>
-#include <QDebug>
-#include <QMetaObject>
-
+#include "embeddedshellextension.h"
 #include "globaloverlay_adaptor.h"
 #include "screen_adaptor.h"
 #include "taskswitcher_adaptor.h"
+#include <QAbstractListModel>
+#include <QDBusConnection>
+#include <QDBusError>
+#include <QDebug>
+#include <QMetaObject>
 
 Q_LOGGING_CATEGORY(compositorDBus, "compositor.dbus")
 
 DBusInterface::DBusInterface(const QString &objectPath, QObject *parent)
-    : QObject(parent)
-    , m_objectPath(objectPath)
-{
-}
+    : QObject(parent), m_objectPath(objectPath) {}
 
-void DBusInterface::classBegin()
-{
-}
+void DBusInterface::classBegin() {}
 
-void DBusInterface::componentComplete()
-{
-    Q_ASSERT_X(findChild<QDBusAbstractAdaptor *>(), "DBusInterface", "DBusInterface constructed without attached DBus adaptor");
+void DBusInterface::componentComplete() {
+  Q_ASSERT_X(findChild<QDBusAbstractAdaptor *>(), "DBusInterface",
+             "DBusInterface constructed without attached DBus adaptor");
 
-    const bool valid = busConnection().registerObject(m_objectPath, this);
-    if (!valid) {
-        qCWarning(compositorDBus) << "Failed to register interface" << interfaceName() << "on" << objectPath();
-        return;
+  const bool valid = busConnection().registerObject(m_objectPath, this);
+  if (!valid) {
+    qCWarning(compositorDBus) << "Failed to register interface"
+                              << interfaceName() << "on" << objectPath();
+    return;
+  }
+
+  const QMetaMethod propertyChangedSlot =
+      metaObject()->method(metaObject()->indexOfMethod("onPropertyChanged()"));
+  Q_ASSERT(propertyChangedSlot.isValid());
+
+  // Qt DBus does not automatically emit the properties changed signal, hook it
+  // up manually.
+  const auto mo = metaObject();
+  for (int i = mo->propertyOffset(); i < mo->propertyCount(); ++i) {
+    const auto prop = mo->property(i);
+    if (!prop.hasNotifySignal()) {
+      continue;
     }
 
-    const QMetaMethod propertyChangedSlot = metaObject()->method(metaObject()->indexOfMethod("onPropertyChanged()"));
-    Q_ASSERT(propertyChangedSlot.isValid());
+    const auto notifySignal = prop.notifySignal();
+    const bool ok = connect(this, notifySignal, this, propertyChangedSlot);
+    Q_ASSERT(ok);
+  }
 
-    // Qt DBus does not automatically emit the properties changed signal, hook it up manually.
-    const auto mo = metaObject();
-    for (int i = mo->propertyOffset(); i < mo->propertyCount(); ++i) {
-        const auto prop = mo->property(i);
-        if (!prop.hasNotifySignal()) {
-            continue;
-        }
+  qCDebug(compositorDBus) << "Registered interface" << interfaceName() << "on"
+                          << objectPath();
+  m_valid = valid;
+  Q_EMIT validChanged(valid);
+}
 
-        const auto notifySignal = prop.notifySignal();
-        const bool ok = connect(this, notifySignal, this, propertyChangedSlot);
-        Q_ASSERT(ok);
+QDBusConnection DBusInterface::busConnection() const { return getBus(); }
+
+QString DBusInterface::interfaceName() const {
+  const auto *adaptor = findChild<QDBusAbstractAdaptor *>();
+  const auto mo = adaptor->metaObject();
+  const int classInfoIdx = mo->indexOfClassInfo("D-Bus Interface");
+  Q_ASSERT(classInfoIdx > -1);
+  const auto classInfo = mo->classInfo(classInfoIdx);
+  return QString::fromUtf8(classInfo.value());
+}
+
+QString DBusInterface::objectPath() const { return m_objectPath; }
+
+bool DBusInterface::valid() const { return m_valid; }
+
+void DBusInterface::onPropertyChanged() {
+  const auto mo = metaObject();
+
+  Q_ASSERT(sender() == this);
+  const auto emittedSignal = mo->method(senderSignalIndex());
+
+  QMetaProperty changedProperty;
+
+  // Find the property that belongs to this signal and emit the DBus signal.
+  for (int i = mo->propertyOffset(); i < mo->propertyCount(); ++i) {
+    const auto prop = mo->property(i);
+    if (!prop.hasNotifySignal()) {
+      continue;
     }
 
-    qCDebug(compositorDBus) << "Registered interface" << interfaceName() << "on" << objectPath();
-    m_valid = valid;
-    Q_EMIT validChanged(valid);
-}
-
-QDBusConnection DBusInterface::busConnection() const
-{
-    return getBus();
-}
-
-QString DBusInterface::interfaceName() const
-{
-    const auto *adaptor = findChild<QDBusAbstractAdaptor *>();
-    const auto mo = adaptor->metaObject();
-    const int classInfoIdx = mo->indexOfClassInfo("D-Bus Interface");
-    Q_ASSERT(classInfoIdx > -1);
-    const auto classInfo = mo->classInfo(classInfoIdx);
-    return QString::fromUtf8(classInfo.value());
-}
-
-QString DBusInterface::objectPath() const
-{
-    return m_objectPath;
-}
-
-bool DBusInterface::valid() const
-{
-    return m_valid;
-}
-
-void DBusInterface::onPropertyChanged()
-{
-    const auto mo = metaObject();
-
-    Q_ASSERT(sender() == this);
-    const auto emittedSignal = mo->method(senderSignalIndex());
-
-    QMetaProperty changedProperty;
-
-    // Find the property that belongs to this signal and emit the DBus signal.
-    for (int i = mo->propertyOffset(); i < mo->propertyCount(); ++i) {
-        const auto prop = mo->property(i);
-        if (!prop.hasNotifySignal()) {
-            continue;
-        }
-
-        if (prop.notifySignal() == emittedSignal) {
-            changedProperty = prop;
-            break;
-        }
+    if (prop.notifySignal() == emittedSignal) {
+      changedProperty = prop;
+      break;
     }
+  }
 
-    Q_ASSERT(changedProperty.isValid());
+  Q_ASSERT(changedProperty.isValid());
 
-    QDBusMessage signal = QDBusMessage::createSignal(objectPath(),
-                                                     QStringLiteral("org.freedesktop.DBus.Properties"),
-                                                     QStringLiteral("PropertiesChanged"));
-    signal.setArguments({
-        interfaceName(),
-        QVariantMap{
-            { QString::fromUtf8(changedProperty.name()), changedProperty.read(this) }
-        },
-        QStringList(), // invalidated.
-    });
+  QDBusMessage signal = QDBusMessage::createSignal(
+      objectPath(), QStringLiteral("org.freedesktop.DBus.Properties"),
+      QStringLiteral("PropertiesChanged"));
+  signal.setArguments({
+      interfaceName(),
+      QVariantMap{{QString::fromUtf8(changedProperty.name()),
+                   changedProperty.read(this)}},
+      QStringList(), // invalidated.
+  });
 
-    busConnection().send(signal);
+  busConnection().send(signal);
 }
 
 bool InitDbusConnection(QString serviceName) {
@@ -132,57 +121,102 @@ bool InitDbusConnection(QString serviceName) {
 }
 
 TaskSwitcherInterface::TaskSwitcherInterface(QObject *parent)
-    : DBusInterface(QStringLiteral("/taskswitcher"), parent)
-{
-    new TaskswitcherAdaptor(this);
+    : DBusInterface(QStringLiteral("/taskswitcher"), parent) {
+  new TaskswitcherAdaptor(this);
 }
 
-void TaskSwitcherInterface::Open()
-{
-    Q_EMIT openRequested();
+void TaskSwitcherInterface::Open() { Q_EMIT openRequested(); }
+
+void TaskSwitcherInterface::Close() { Q_EMIT closeRequested(); }
+
+QString TaskSwitcherInterface::currentView() const { return m_currentView; }
+
+void TaskSwitcherInterface::setCurrentView(QString newCurrentView) {
+  qDebug() << "new current view " << newCurrentView;
+  if (m_currentView == newCurrentView)
+    return;
+  m_currentView = newCurrentView;
+  emit currentViewChanged(m_currentView);
 }
 
-void TaskSwitcherInterface::Close()
-{
-    Q_EMIT closeRequested();
+const QList<TaskSwitcherEntry> &TaskSwitcherInterface::views() const {
+  return m_views;
+}
+
+QDBusArgument &operator<<(QDBusArgument &argument,
+                          const TaskSwitcherEntry &entry) {
+  argument.beginStructure();
+  argument << entry.uuid << entry.pid << entry.label;
+  argument.endStructure();
+  return argument;
+}
+
+const QDBusArgument &operator>>(const QDBusArgument &argument,
+                                TaskSwitcherEntry &entry) {
+  argument.beginStructure();
+  argument >> entry.uuid >> entry.pid >> entry.label;
+  argument.endStructure();
+  return argument;
 }
 
 GlobalOverlayInterface::GlobalOverlayInterface(QObject *parent)
-    : DBusInterface(QStringLiteral("/globaloverlay"), parent)
-{
-    new GlobaloverlayAdaptor(this);
+    : DBusInterface(QStringLiteral("/globaloverlay"), parent) {
+  new GlobaloverlayAdaptor(this);
 }
 
-void GlobalOverlayInterface::Show(const QString &message)
-{
-    Q_EMIT showRequested(message);
+void GlobalOverlayInterface::Show(const QString &message) {
+  Q_EMIT showRequested(message);
 }
 
-void GlobalOverlayInterface::Hide()
-{
-    Q_EMIT hideRequested();
-}
+void GlobalOverlayInterface::Hide() { Q_EMIT hideRequested(); }
 
 CompositorScreenInterface::CompositorScreenInterface(QObject *parent)
-    : DBusInterface(QStringLiteral("/screen"), parent)
-{
-    new ScreenAdaptor(this);
+    : DBusInterface(QStringLiteral("/screen"), parent) {
+  new ScreenAdaptor(this);
 
-    m_orientation = qEnvironmentVariable("SCREEN_ORIENTATION");
-    if (m_orientation.isEmpty()) {
-        m_orientation = QStringLiteral("0");
-    }
+  m_orientation = qEnvironmentVariable("SCREEN_ORIENTATION");
+  if (m_orientation.isEmpty()) {
+    m_orientation = QStringLiteral("0");
+  }
 }
 
-QString CompositorScreenInterface::orientation() const
-{
-    return m_orientation;
+QString CompositorScreenInterface::orientation() const { return m_orientation; }
+
+void CompositorScreenInterface::setOrientation(const QString &orientation) {
+  if (m_orientation != orientation) {
+    m_orientation = orientation;
+    Q_EMIT orientationChanged(orientation);
+  }
 }
 
-void CompositorScreenInterface::setOrientation(const QString &orientation)
-{
-    if (m_orientation != orientation) {
-        m_orientation = orientation;
-        Q_EMIT orientationChanged(orientation);
-    }
+QAbstractListModel *TaskSwitcherInterface::viewModel() const {
+  return m_viewModel;
+}
+
+void TaskSwitcherInterface::setViewModel(QAbstractListModel *newViewModel) {
+  if (m_viewModel == newViewModel)
+    return;
+  connect(newViewModel, &QAbstractItemModel::rowsInserted, this,
+          &TaskSwitcherInterface::publishViews);
+  connect(newViewModel, &QAbstractItemModel::rowsRemoved, this,
+          &TaskSwitcherInterface::publishViews);
+  m_viewModel = newViewModel;
+  emit viewModelChanged(m_viewModel);
+}
+
+void TaskSwitcherInterface::publishViews() {
+  QList<TaskSwitcherEntry> list;
+  for (auto i = 0; i < m_viewModel->rowCount(); i++) {
+    auto d = m_viewModel->index(i).data().toMap();
+    auto surface = d["surface"].value<EmbeddedShellSurface *>();
+    auto view = d["view"].value<EmbeddedShellSurfaceView *>();
+
+    list.append({
+        view ? view->getUuid() : surface->getUuid(),
+        view ? view->label() : "surface",
+        surface->getClientPid(),
+    });
+  }
+  m_views = list;
+  emit viewsChanged(m_views);
 }

--- a/embedded-compositor/dbusinterface.h
+++ b/embedded-compositor/dbusinterface.h
@@ -3,6 +3,7 @@
 #ifndef DBUSINTERFACE_H
 #define DBUSINTERFACE_H
 
+#include <QDBusArgument>
 #include <QDBusConnection>
 #include <QDBusContext>
 #include <QLoggingCategory>
@@ -13,92 +14,135 @@ Q_DECLARE_LOGGING_CATEGORY(compositorDBus)
 
 bool InitDbusConnection(QString serviceName);
 
-class DBusInterface : public QObject, public QQmlParserStatus, protected QDBusContext
-{
-    Q_OBJECT
-    Q_INTERFACES(QQmlParserStatus)
+class DBusInterface : public QObject,
+                      public QQmlParserStatus,
+                      protected QDBusContext {
+  Q_OBJECT
+  Q_INTERFACES(QQmlParserStatus)
 
-    Q_PROPERTY(QString interfaceName READ interfaceName CONSTANT)
-    Q_PROPERTY(QString objectPath READ objectPath CONSTANT)
-    Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
+  Q_PROPERTY(QString interfaceName READ interfaceName CONSTANT)
+  Q_PROPERTY(QString objectPath READ objectPath CONSTANT)
+  Q_PROPERTY(bool valid READ valid NOTIFY validChanged)
 
 public:
-    ~DBusInterface() override = default;
+  ~DBusInterface() override = default;
 
-    QDBusConnection busConnection() const;
-    QString interfaceName() const;
-    QString objectPath() const;
+  QDBusConnection busConnection() const;
+  QString interfaceName() const;
+  QString objectPath() const;
 
-    bool valid() const;
-    Q_SIGNAL void validChanged(bool valid);
+  bool valid() const;
+  Q_SIGNAL void validChanged(bool valid);
 
 protected:
-    DBusInterface(const QString &objectPath, QObject *parent = nullptr);
+  DBusInterface(const QString &objectPath, QObject *parent = nullptr);
 
-    // QQmlParserStatus
-    void classBegin() override;
-    void componentComplete() override;
+  // QQmlParserStatus
+  void classBegin() override;
+  void componentComplete() override;
 
 private Q_SLOTS:
-    void onPropertyChanged();
+  void onPropertyChanged();
 
 private:
-    QString m_objectPath;
-    bool m_valid = false;
+  QString m_objectPath;
+  bool m_valid = false;
 };
 
-class TaskSwitcherInterface : public DBusInterface
-{
-    Q_OBJECT
+class QAbstractListModel;
 
-public:
-    TaskSwitcherInterface(QObject *parent = nullptr);
-    ~TaskSwitcherInterface() override = default;
-
-    // DBus
-    void Open();
-    void Close();
-
-Q_SIGNALS:
-    void openRequested();
-    void closeRequested();
+struct TaskSwitcherEntry {
+  QString uuid;
+  QString label;
+  int pid;
 };
 
-class GlobalOverlayInterface : public DBusInterface
-{
-    Q_OBJECT
+Q_DECLARE_METATYPE(TaskSwitcherEntry)
+Q_DECLARE_METATYPE(QList<TaskSwitcherEntry>)
+
+QDBusArgument &operator<<(QDBusArgument &argument,
+                          const TaskSwitcherEntry &entry);
+
+const QDBusArgument &operator>>(const QDBusArgument &argument,
+                                TaskSwitcherEntry &entry);
+
+class TaskSwitcherInterface : public DBusInterface {
+  Q_OBJECT
 
 public:
-    GlobalOverlayInterface(QObject *parent = nullptr);
-    ~GlobalOverlayInterface() override = default;
+  TaskSwitcherInterface(QObject *parent = nullptr);
+  ~TaskSwitcherInterface() override = default;
 
-    // DBus
-    void Show(const QString &message);
-    void Hide();
+  Q_PROPERTY(QString currentView READ currentView WRITE setCurrentView NOTIFY
+                 currentViewChanged)
+  Q_PROPERTY(QList<TaskSwitcherEntry> views READ views NOTIFY viewsChanged)
+  Q_PROPERTY(QAbstractListModel *viewModel READ viewModel WRITE setViewModel
+                 NOTIFY viewModelChanged)
 
-Q_SIGNALS:
-    void showRequested(const QString &message);
-    void hideRequested();
-};
+  // DBus
+  void Open();
+  void Close();
 
-class CompositorScreenInterface : public DBusInterface
-{
-    Q_OBJECT
+  QString currentView() const;
+  void setCurrentView(QString newCurrentView);
 
-    Q_PROPERTY(QString orientation READ orientation WRITE setOrientation NOTIFY orientationChanged)
+  const QList<TaskSwitcherEntry> &views() const;
 
-public:
-    CompositorScreenInterface(QObject *parent = nullptr);
-    ~CompositorScreenInterface() override = default;
+  QAbstractListModel *viewModel() const;
+  void setViewModel(QAbstractListModel *newViewModel);
 
-    QString orientation() const;
-    void setOrientation(const QString &orientation);
+public slots:
 
 Q_SIGNALS:
-    void orientationChanged(const QString &orientation);
+  void openRequested();
+  void closeRequested();
+  void currentViewChanged(QString CurrentView);
+  void viewsChanged(const QList<TaskSwitcherEntry> &views);
+
+  void viewModelChanged(QAbstractListModel *viewModel);
 
 private:
-    QString m_orientation;
+  QString m_currentView;
+  QList<TaskSwitcherEntry> m_views = {};
+  QAbstractListModel *m_viewModel = nullptr;
+private slots:
+  void publishViews();
+};
+
+class GlobalOverlayInterface : public DBusInterface {
+  Q_OBJECT
+
+public:
+  GlobalOverlayInterface(QObject *parent = nullptr);
+  ~GlobalOverlayInterface() override = default;
+
+  // DBus
+  void Show(const QString &message);
+  void Hide();
+
+Q_SIGNALS:
+  void showRequested(const QString &message);
+  void hideRequested();
+};
+
+class CompositorScreenInterface : public DBusInterface {
+  Q_OBJECT
+
+  Q_PROPERTY(QString orientation READ orientation WRITE setOrientation NOTIFY
+                 orientationChanged)
+
+public:
+  CompositorScreenInterface(QObject *parent = nullptr);
+  ~CompositorScreenInterface() override = default;
+
+  QString orientation() const;
+  void setOrientation(const QString &orientation);
+
+Q_SIGNALS:
+  void orientationChanged(const QString &orientation);
+
+private:
+  QString m_orientation;
 };
 
 #endif // DBUSINTERFACE_H

--- a/embedded-compositor/embedded-compositor.pro
+++ b/embedded-compositor/embedded-compositor.pro
@@ -1,5 +1,6 @@
 QT += core gui waylandcompositor waylandcompositor-private core-private gui-private quick dbus
 CONFIG += c++17 wayland-scanner
+# CONFIG += sanitizer sanitize_address
 
 use_system_bus {
     message(using system dbus)

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -70,7 +70,8 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
       m_surface(surface), m_anchor(anchor), m_margin(margin),
       m_sort_index(sort_index) {
   Q_UNUSED(ext)
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << anchor;
+  qCDebug(shellExt) << __PRETTY_FUNCTION__ << anchor
+                    << wl_resource_get_id(resource.resource());
   init(resource.resource());
   setExtensionContainer(surface);
   QWaylandCompositorExtension::initialize();
@@ -96,6 +97,18 @@ void EmbeddedShellSurface::setSortIndex(int sort_index) {
 void EmbeddedShellSurface::sendConfigure(const QSize size) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << size;
   send_configure(size.width(), size.height());
+}
+
+QString EmbeddedShellSurface::getUuid() const {
+  return m_uuid.toString(QUuid::WithoutBraces);
+}
+
+pid_t EmbeddedShellSurface::getClientPid() const {
+  pid_t pid;
+  uid_t uid;
+  gid_t gid;
+  wl_client_get_credentials(resource()->client(), &pid, &uid, &gid);
+  return pid;
 }
 
 QuickEmbeddedShellIntegration::QuickEmbeddedShellIntegration(
@@ -177,6 +190,10 @@ void EmbeddedShellSurfaceView::setSortIndex(int newSortIndex) {
     return;
   m_sortIndex = newSortIndex;
   emit sortIndexChanged(m_sortIndex);
+}
+
+QString EmbeddedShellSurfaceView::getUuid() const {
+  return m_uuid.toString(QUuid::WithoutBraces);
 }
 
 void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -6,6 +6,7 @@
 #include <QtWaylandCompositor/QWaylandShellSurfaceTemplate>
 #include <QtWaylandCompositor/QWaylandShellTemplate>
 
+#include "quuid.h"
 #include "qwayland-server-embedded-shell.h"
 #include <QWaylandResource>
 #include <QtWaylandCompositor/QWaylandCompositor>
@@ -63,11 +64,14 @@ public:
       EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
   Q_PROPERTY(int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 
   void setAnchor(embedded_shell_anchor_border newAnchor);
   void setMargin(int newMargin);
   void setSortIndex(int sort_index);
   Q_INVOKABLE void sendConfigure(const QSize size);
+  QString getUuid() const;
+  pid_t getClientPid() const;
 
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
@@ -80,6 +84,7 @@ private:
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
   int32_t m_sort_index = 0;
+  QUuid m_uuid = QUuid::createUuid();
 
   // embedded_shell_surface interface
 protected:
@@ -100,6 +105,7 @@ class EmbeddedShellSurfaceView : public QObject,
   Q_OBJECT
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 public:
   EmbeddedShellSurfaceView(const QString &label, int32_t sort_index,
                            wl_client *client, int id, int version)
@@ -110,6 +116,8 @@ public:
 
   int sortIndex() const;
   void setSortIndex(int newSortIndex);
+
+  QString getUuid() const;
 
 public slots:
   void select() { surface_view::send_selected(); }
@@ -123,6 +131,7 @@ protected:
                                    int32_t sort_index) override;
 
 private:
+  QUuid m_uuid = QUuid::createUuid();
   QString m_label;
   int32_t m_sortIndex = 0;
 };

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -3,6 +3,7 @@
 #include "dbusinterface.h"
 #include "embeddedshellextension.h"
 #include "notificationmodel.h"
+#include <QDBusMetaType>
 #include <QtCore/QDebug>
 #include <QtCore/QUrl>
 #include <QtGui/QGuiApplication>
@@ -21,8 +22,18 @@ int main(int argc, char *argv[]) {
   qmlRegisterUncreatableType<EmbeddedShellSurfaceView>(
       "com.embeddedcompositor.embeddedshell", 1, 0, "SurfaceView",
       "managed by wayland");
+
+  qmlRegisterUncreatableType<QAbstractListModel>(
+      "com.embeddedcompositor.embeddedshell", 1, 0, "QAbstractListModel",
+      "only a property");
+
   qmlRegisterType<TaskSwitcherInterface>("com.embeddedcompositor.dbus", 1, 0,
                                          "TaskSwitcherInterface");
+  qDBusRegisterMetaType<TaskSwitcherEntry>();
+  qDBusRegisterMetaType<QList<TaskSwitcherEntry>>();
+  qRegisterMetaType<TaskSwitcherEntry>("TaskSwitcherEntry");
+  qRegisterMetaType<QList<TaskSwitcherEntry>>("QList<TaskSwitcherEntry>");
+
   qmlRegisterType<GlobalOverlayInterface>("com.embeddedcompositor.dbus", 1, 0,
                                           "GlobalOverlayInterface");
 

--- a/embedded-compositor/qml/DefaultTaskSwitcher/TaskSwitcher.qml
+++ b/embedded-compositor/qml/DefaultTaskSwitcher/TaskSwitcher.qml
@@ -92,7 +92,9 @@ Rectangle {
             Text {
                 id: text
                 anchors.centerIn: parent
-                text: (view? ("<"+view.label+"> "+view.sortIndex) : "NOT VIEW "+shellSurface.sortIndex+" "+JSON.stringify(shellSurface))
+                text: (view?
+                           ("<"+view.label+"> "+view.sortIndex+" view id "+view.uuid)
+                         : "NOT VIEW "+shellSurface.sortIndex+" "+JSON.stringify(shellSurface,null,2)) + "\nsurf:"+shellSurface.uuid
                 color:"white"
             }
 


### PR DESCRIPTION
create dbus interface for switching current view to a different one. 

* surfaces/views are identiefied by uuid
* list of views includes uuid, label and process id for easy identification of the view

Fixes #2 