### PR TITLE
embedded-compositor.pro: drop dev-tools from SUBDIRS list

### DIFF
--- a/embedded-compositor.pro
+++ b/embedded-compositor.pro
@@ -4,11 +4,9 @@ SUBDIRS = shellintegration \
         embedded-compositor \
         embeddedplatform \
         quickembeddedshellwindow \
-        dev-tools
 
 OTHER_FILES = protocol/*.xml dbus/*.xml .qmake.conf
 
 shellintegration.depends += embeddedplatform
 quickembeddedshellwindow.depends += embeddedplatform
 dev-tools.depends += quickembeddedshellwindow
-


### PR DESCRIPTION
By this change the dev-tools will no longer installed by default. It is part of the Yocto-meta-layer from now on. The meta-layer provides a split-package (IPK) which could be installed via opkg.