### PR TITLE
Check if screen saver is enabled before timer restart

### DIFF
--- a/embedded-compositor/qml/ScreenSaverController.qml
+++ b/embedded-compositor/qml/ScreenSaverController.qml
@@ -22,7 +22,9 @@ Item {
     function reset()
     {
         screenSaverLoader.active = false;
-        screenSaverTimeOut.restart();
+        if(screenSaverEnabled) {
+            screenSaverTimeOut.restart();
+        }
     }
 
     onScreenSaverEnabledChanged: {


### PR DESCRIPTION
When the reset function was called on a disabled screensaver, the screenSaverTimeOut timer would start anyway.