### PR TITLE
remove incorrect build settings

### DIFF
--- a/.qmake.conf
+++ b/.qmake.conf
@@ -1,3 +1,2 @@
-load(qt_build_config)
 top_srcdir=$$PWD
 top_builddir=$$shadowed($$PWD)


### PR DESCRIPTION
qt_build_config was introduced at some point because it appeared to fix building of the wayland qpa shell plugin if I remember correctly. However it also introduces a lot of unrelated build flags, one of them create_prl which causes all of our test clients to link against Qt5XkbCommonSupport and Qt5ServiceSupport which is not required.