### PR TITLE
WaylandInputRegion: Disconnect ready signal once done

### DIFF
--- a/quickembeddedshellwindow/waylandinputregion.cpp
+++ b/quickembeddedshellwindow/waylandinputregion.cpp
@@ -55,6 +55,9 @@ void WaylandInputRegion::updateRegion() {
   auto result = grabToImage(aligned.size());
   connect(result.data(), &QQuickItemGrabResult::ready, this, [=](){
       this->SetImage(result->image(), aligned);
+      // QSharedPointer captured into this lambda remains alive indefinitely.
+      // Disconnect, to dispose of the lambda and subsequently the object held by the shared pointer.
+      disconnect(result.data(), &QQuickItemGrabResult::ready, this, nullptr);
     });
 }
 


### PR DESCRIPTION
The QSharedPointer is copied into the lambda, thus has a ref-count of 2. The original falls out of scope, and we're left with a ref-count of 1.

The connection is never severed, so the grab result remains alive indefinitely.

Explicitly disconnect the lambda once we're done with it, so the ref-count drops to zero, and we properly dispose of the QQuickItemGrabResult.

(In Qt 6 we could use Qt::SingleShotConnection.)