### PR TITLE
WaylandInputRegion: Introduce active properly

### DIFF
--- a/quickembeddedshellwindow/waylandinputregion.cpp
+++ b/quickembeddedshellwindow/waylandinputregion.cpp
@@ -12,6 +12,24 @@ WaylandInputRegion::WaylandInputRegion(QQuickItem* parent): QQuickItem(parent) {
     setFlag(QQuickItem::ItemHasContents);
 }
 
+bool WaylandInputRegion::active() const
+{
+    return m_active;
+}
+
+void WaylandInputRegion::setActive(bool active)
+{
+    if (m_active == active) {
+        return;
+    }
+
+    m_active = active;
+    if (isComponentComplete()) {
+        updateRegion();
+    }
+    Q_EMIT activeChanged(active);
+}
+
 void WaylandInputRegion::itemChange(ItemChange c, const ItemChangeData& d) {
     updateRegion();
     QQuickItem::itemChange(c,d);
@@ -42,6 +60,12 @@ void WaylandInputRegion::updateRegion() {
   if(window() == nullptr) {
       return;
   }
+
+  if (!m_active) {
+      window()->handle()->setMask(QRegion());
+      return;
+  }
+
   // if we have no item to create a mask from, we can just use ourselves as a rectangle
   auto mapped = mapRectToScene(boundingRect());
   auto aligned = mapped.toAlignedRect();

--- a/quickembeddedshellwindow/waylandinputregion.h
+++ b/quickembeddedshellwindow/waylandinputregion.h
@@ -18,6 +18,14 @@ class WaylandInputRegion : public QQuickItem
 public:
     explicit WaylandInputRegion(QQuickItem *parent = nullptr);
     Q_PROPERTY(bool pixelMask READ pixelMask WRITE setPixelMask NOTIFY pixelMaskChanged)
+    /**
+     * @brief Whether masking is active
+     *
+     * When set to false, the window mask is reset.
+     * Default is true.
+     */
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
+
 protected:
     void itemChange(ItemChange, const ItemChangeData &) override;
     void geometryChanged(const QRectF &newGeometry, const QRectF &oldGeometry) override;
@@ -39,11 +47,16 @@ public:
         emit pixelMaskChanged(m_pixelMask);
     }
 
+    bool active() const;
+    void setActive(bool active);
+    Q_SIGNAL void activeChanged(bool active);
+
 signals:
     void pixelMaskChanged(bool mask);
 
 private:
     bool m_pixelMask = false;
+    bool m_active = true;
 };
 
 #endif // WAYLANDINPUTREGION_H


### PR DESCRIPTION
Allows disabling masking completely in case the view should be fully interactive again, such as when showing a full-screen overlay.