### PR TITLE
WaylandInputRegion: Don't set ItemHasContents

### DIFF
--- a/quickembeddedshellwindow/waylandinputregion.cpp
+++ b/quickembeddedshellwindow/waylandinputregion.cpp
@@ -9,7 +9,6 @@
 #include <QPainter>
 
 WaylandInputRegion::WaylandInputRegion(QQuickItem* parent): QQuickItem(parent) {
-    setFlag(QQuickItem::ItemHasContents);
 }
 
 void WaylandInputRegion::itemChange(ItemChange c, const ItemChangeData& d) {


### PR DESCRIPTION
This is only relevant when doing rendering inside the item itself (e.g. updatePaintNode). We don't do that, we only have visual items as our children.