### PR TITLE
include the `git describe --tags --always` information 

### DIFF
--- a/embedded-compositor/embedded-compositor.pro
+++ b/embedded-compositor/embedded-compositor.pro
@@ -58,3 +58,6 @@ INSTALLS += target
 
 WAYLANDSERVERSOURCES += ../protocol/embedded-shell.xml
 INCLUDEPATH += $$top_srcdir/embeddedplatform
+
+EMBEDDED_COMPOSITOR_VERSION = $$system(git describe --tags --always)
+DEFINES += EMBEDDED_COMPOSITOR_VERSION=\\\"$$EMBEDDED_COMPOSITOR_VERSION\\\"

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -13,6 +13,7 @@
 #include <sortfilterproxymodel.h>
 
 int main(int argc, char *argv[]) {
+  qInfo() << "Version: " << QStringLiteral(EMBEDDED_COMPOSITOR_VERSION);
   qputenv("QT_SCREEN_SCALE_FACTORS", "");
   qputenv("QT_AUTO_SCREEN_SCALE_FACTOR", "0");
 


### PR DESCRIPTION
On each build the `git describe` output will compiled in. 
It will printed out on `stdout` 