### PR TITLE
Add concept of "apps" to Embedded Shell Surface

### DIFF
--- a/dbus/de.EmbeddedCompositor.taskswitcher.xml
+++ b/dbus/de.EmbeddedCompositor.taskswitcher.xml
@@ -6,7 +6,8 @@
 <method name="Open"/>
 <method name="Close"/>
 <property name="currentView" type="s" access="readwrite"/>
-<property name="views" type="a(ssu)"  access="read" >
+<!-- app id, app label, app icon, view label, view icon, pid, properties -->
+<property name="views" type="a(ssssssia{sv})"  access="read" >
     <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
 </property>
 </interface>

--- a/embedded-compositor/dbusinterface.cpp
+++ b/embedded-compositor/dbusinterface.cpp
@@ -146,7 +146,7 @@ const QList<TaskSwitcherEntry> &TaskSwitcherInterface::views() const {
 QDBusArgument &operator<<(QDBusArgument &argument,
                           const TaskSwitcherEntry &entry) {
   argument.beginStructure();
-  argument << entry.uuid << entry.pid << entry.label;
+  argument << entry.uuid << entry.appId << entry.appLabel << entry.appIcon << entry.label << entry.icon << entry.pid << entry.args;
   argument.endStructure();
   return argument;
 }
@@ -154,7 +154,7 @@ QDBusArgument &operator<<(QDBusArgument &argument,
 const QDBusArgument &operator>>(const QDBusArgument &argument,
                                 TaskSwitcherEntry &entry) {
   argument.beginStructure();
-  argument >> entry.uuid >> entry.pid >> entry.label;
+  argument >> entry.uuid >> entry.appId >> entry.appLabel >> entry.appIcon >> entry.label >> entry.icon >> entry.pid >> entry.args;
   argument.endStructure();
   return argument;
 }
@@ -208,8 +208,13 @@ void TaskSwitcherInterface::publishViews() {
 
     list.append({
         view ? view->getUuid() : surface->getUuid(),
+        view ? view->appId() : QString(),
+        view ? view->appLabel() : QString(),
+        view ? view->appIcon() : QString(),
         view ? view->label() : "surface",
-        surface->getClientPid(),
+        view ? view->icon() : QString(),
+        uint32_t(surface->getClientPid()),
+        QVariantMap(), //args
     });
   }
   m_views = list;

--- a/embedded-compositor/dbusinterface.h
+++ b/embedded-compositor/dbusinterface.h
@@ -53,8 +53,13 @@ class QAbstractListModel;
 
 struct TaskSwitcherEntry {
   QString uuid;
+  QString appId;
+  QString appLabel;
+  QString appIcon;
   QString label;
-  int pid;
+  QString icon;
+  uint32_t pid;
+  QVariantMap args; // for future extension
 };
 
 Q_DECLARE_METATYPE(TaskSwitcherEntry)

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -148,27 +148,149 @@ void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_view_create(
-    Resource *resource, wl_resource *shell_surface, const QString &label,
-    int32_t sort_index, uint32_t id) {
+    Resource *resource, wl_resource *shell_surface, const QString &appId, const QString &appLabel, const QString &appIcon,
+    const QString &label, const QString &icon, int32_t sort_index, uint32_t id) {
   Q_UNUSED(shell_surface)
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << label << id;
-  auto view = new EmbeddedShellSurfaceView(label, sort_index,
+  qCDebug(shellExt) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << id;
+  auto view = new EmbeddedShellSurfaceView(appId, appLabel, appIcon, label, icon, sort_index,
                                            resource->client(), id, 1);
   emit createView(view);
 }
 
-void EmbeddedShellSurfaceView::setLabel(const QString &newLabel) {
-  if (m_label == newLabel)
-    return;
-  m_label = newLabel;
-  emit labelChanged();
+EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
+                                                   const QString &label,
+                                                   const QString &icon,
+                                                   int32_t sort_index,
+                                                   wl_client *client,
+                                                   int id, int version)
+    : QtWaylandServer::surface_view(client, id, version)
+    , m_appId(appId)
+    , m_label(label)
+    , m_icon(icon)
+    , m_sortIndex(sort_index)
+{
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource,
-                                                      const QString &text) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << text;
-  Q_UNUSED(resource)
-  setLabel(text);
+EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
+                                                   const QString &appLabel,
+                                                   const QString &appIcon,
+                                                   const QString &label,
+                                                   const QString &icon,
+                                                   int32_t sort_index,
+                                                   wl_client *client,
+                                                   int id, int version)
+    : QtWaylandServer::surface_view(client, id, version)
+    , m_appId(appId)
+    , m_appLabel(appLabel)
+    , m_appIcon(appIcon)
+    , m_label(label)
+    , m_icon(icon)
+    , m_sortIndex(sort_index)
+{
+}
+
+QString EmbeddedShellSurfaceView::appId() const
+{
+    return m_appId;
+}
+
+void EmbeddedShellSurfaceView::setAppId(const QString &appId)
+{
+    if (m_appId == appId) {
+        return;
+    }
+
+    // TODO prevent changing after it was initialized.
+    m_appId = appId;
+    Q_EMIT appIdChanged(appId);
+}
+
+QString EmbeddedShellSurfaceView::appLabel() const
+{
+    return m_appLabel;
+}
+
+void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
+{
+    if (m_appLabel == appLabel) {
+        return;
+    }
+
+    m_appLabel = appLabel;
+    Q_EMIT appLabelChanged(appLabel);
+}
+
+QString EmbeddedShellSurfaceView::appIcon() const
+{
+    return m_appIcon;
+}
+
+void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
+{
+    if (m_appIcon == appIcon) {
+        return;
+    }
+
+    m_appIcon = appIcon;
+    Q_EMIT appIconChanged(appIcon);
+}
+
+QString EmbeddedShellSurfaceView::label() const
+{
+    return m_label;
+}
+
+void EmbeddedShellSurfaceView::setLabel(const QString &label)
+{
+    if (m_label == label) {
+        return;
+    }
+
+    m_label = label;
+    Q_EMIT labelChanged(label);
+}
+
+QString EmbeddedShellSurfaceView::icon() const
+{
+    return m_icon;
+}
+
+void EmbeddedShellSurfaceView::setIcon(const QString &icon)
+{
+    if (m_icon == icon) {
+        return;
+    }
+
+    m_icon = icon;
+    Q_EMIT iconChanged(icon);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_app_label(Resource *resource, const QString &label)
+{
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << label;
+    Q_UNUSED(resource);
+    setAppLabel(label);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_app_icon(Resource *resource, const QString &icon)
+{
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << icon;
+    Q_UNUSED(resource);
+    setAppIcon(icon);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource, const QString &text)
+{
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << text;
+    Q_UNUSED(resource)
+    setLabel(text);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_icon(Resource *resource, const QString &icon)
+{
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << icon;
+    Q_UNUSED(resource)
+    setIcon(icon);
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_margin(Resource *resource,

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -92,7 +92,8 @@ protected:
                                          uint32_t anchor) override;
   void embedded_shell_surface_view_create(Resource *resource,
                                           wl_resource *shell_surface,
-                                          const QString &label, int sort_index,
+                                          const QString &appId, const QString &appLabel, const QString &appIcon,
+                                          const QString &label, const QString &icon, int sort_index,
                                           uint32_t id) override;
   void embedded_shell_surface_set_margin(Resource *resource,
                                          int32_t margin) override;
@@ -103,16 +104,39 @@ protected:
 class EmbeddedShellSurfaceView : public QObject,
                                  public QtWaylandServer::surface_view {
   Q_OBJECT
+  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(int sortIndex READ sortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 public:
-  EmbeddedShellSurfaceView(const QString &label, int32_t sort_index,
-                           wl_client *client, int id, int version)
-      : QtWaylandServer::surface_view(client, id, version), m_label(label),
-        m_sortIndex(sort_index) {}
-  const QString &label() const { return m_label; }
-  void setLabel(const QString &newLabel);
+  EmbeddedShellSurfaceView(const QString &appId, const QString &label, const QString &icon,
+                           int32_t sort_index, wl_client *client, int id, int version);
+  EmbeddedShellSurfaceView(const QString &appId, const QString &appLabel, const QString &appIcon,
+                           const QString &label, const QString &icon, int32_t sort_index,
+                           wl_client *client, int id, int version);
+
+  QString appId() const;
+  void setAppId(const QString &appId);
+  Q_SIGNAL void appIdChanged(const QString &appId);
+
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+  Q_SIGNAL void appLabelChanged(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+  Q_SIGNAL void appIconChanged(const QString &appIcon);
+
+  QString label() const;
+  void setLabel(const QString &label);
+  Q_SIGNAL void labelChanged(const QString &label);
+
+  QString icon() const;
+  void setIcon(const QString &icon);
+  Q_SIGNAL void iconChanged(const QString &icon);
 
   int sortIndex() const;
   void setSortIndex(int newSortIndex);
@@ -122,17 +146,23 @@ public:
 public slots:
   void select() { surface_view::send_selected(); }
 signals:
-  void labelChanged();
   void sortIndexChanged(int index);
 
 protected:
+  void surface_view_set_app_label(Resource *resource, const QString &label) override;
+  void surface_view_set_app_icon(Resource *resource, const QString &icon) override;
   void surface_view_set_label(Resource *resource, const QString &text) override;
+  void surface_view_set_icon(Resource *resource, const QString &icon) override;
   void surface_view_set_sort_index(Resource *resource,
                                    int32_t sort_index) override;
 
 private:
   QUuid m_uuid = QUuid::createUuid();
+  QString m_appId;
+  QString m_appLabel;
+  QString m_appIcon;
   QString m_label;
+  QString m_icon;
   int32_t m_sortIndex = 0;
 };
 

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -46,10 +46,30 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_configure(
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
-                                                           int32_t sort_index) {
+                                                           const QString &icon,
+                                                           int32_t sort_index)
+{
+    return createView(QString(), QString(), QString(), label, icon, sort_index);
+}
+
+EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
+                                                           const QString &label,
+                                                           const QString &icon,
+                                                           int32_t sort_index)
+{
+    return createView(appId, QString(), QString(), label, icon, sort_index);
+}
+
+EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
+                                                           const QString &appLabel,
+                                                           const QString &appIcon,
+                                                           const QString &label,
+                                                           const QString &icon,
+                                                           int32_t sort_index)
+{
   Q_D(EmbeddedShellSurface);
   auto view =
-      d->view_create(d->embedded_shell_surface::object(), label, sort_index);
+      d->view_create(d->embedded_shell_surface::object(), appId, appLabel, appIcon, label, icon, sort_index);
   auto ret = new EmbeddedShellSurfaceView(view, this, label);
   return ret;
 }

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -34,6 +34,17 @@ public:
   EmbeddedShellTypes::Anchor getAnchor() const;
   int getSortIndex() const;
   EmbeddedShellSurfaceView *createView(const QString &label,
+                                       const QString &icon,
+                                       int32_t sort_index);
+  EmbeddedShellSurfaceView *createView(const QString &appId,
+                                       const QString &label,
+                                       const QString &icon,
+                                       int32_t sort_index);
+  EmbeddedShellSurfaceView *createView(const QString &appId,
+                                       const QString &appLabel,
+                                       const QString &appIcon,
+                                       const QString &label,
+                                       const QString &icon,
                                        int32_t sort_index);
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -27,8 +27,19 @@
 		</event>
 
 		<request name="view_create">
+			<description summary="create an embedded shell surface_view">
+				Creates an Embedded Shell Surface.
+
+				The app_id identifies the logical application this surface belongs to.
+				The app_label can be empty at which point the label will be used.
+				The app_icon can be empty at which point the icon will be used.
+			</description>
 			<arg name="shell_surface" type="object" interface="embedded_shell_surface" />
-			<arg name="label" type="string" />
+			<arg name="app_id" type="string" summary="The application ID"/>
+			<arg name="app_label" type="string" summary="The user-visible name of the application"/>
+			<arg name="app_icon" type="string" summary="The icon name of the application"/>
+			<arg name="label" type="string" summary="The user-visible label for this particular view"/>
+			<arg name="icon" type="string" summary="The icon name of this particular view"/>
 			<arg name="sort_index" type="int" />
 			<arg name="new_view_id" type="new_id" interface="surface_view" />
 		</request>
@@ -59,7 +70,19 @@
 	</interface>
 
 	<interface name="surface_view" version="1">
+		<request name="set_app_label">
+			<description summary="Set the user-visible application name"/>
+			<arg name="label" type="string" />
+		</request>
+		<request name="set_app_icon">
+			<description summary="Set the application icon name"/>
+			<arg name="label" type="string" />
+		</request>
 		<request name="set_label">
+			<arg name="text" type="string" />
+		</request>
+		<request name="set_icon">
+			<description summary="Set the icon name for this view"/>
 			<arg name="text" type="string" />
 		</request>
 		<request name="set_sort_index">

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -25,10 +25,12 @@ void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor) {
   emit anchorChanged(newAnchor);
 }
 
-EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(QString label,
+EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &appId,
+                                                               const QString &appLabel,
+                                                               const QString &label,
                                                                int sort_index) {
-  auto view = m_surface->createView(label, sort_index);
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << view << label;
+  auto view = m_surface->createView(appId, appLabel, label, sort_index);
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
   return view;
 }
 

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -42,7 +42,7 @@ public:
   void setSortIndex(int sortIndex);
 
 public slots:
-  EmbeddedShellSurfaceView *createView(QString label, int sort_index);
+  EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, int sort_index);
 
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);


### PR DESCRIPTION
Since a single process could spawn several logical applications, this unfortunately cannot be added to the Embedded Shell itself. Also, add icons for apps and views.

Adjust the TaskSwitcher interface to return all those properties. Add a QVariantMap to allow future extension without breaking signature.