### PR TITLE
Add Qt Virtual Keyboard

### DIFF
--- a/dev-tools/run.sh
+++ b/dev-tools/run.sh
@@ -33,7 +33,8 @@ export QT_LOGGING_RULES="embeddedshell.compositor.debug=false;embeddedshell.quic
 export COMPOSITOR_taskSwitcherUrl="file:$BUILD_ROOT/../embedded-compositor/dev-tools/example-components/GridSwitcher.qml"
 #export COMPOSITOR_globalOverlayUrl="file:$BUILD_ROOT/../embedded-compositor/dev-tools/example-components/AltBootScreen.qml"
 #export QT_DEBUG_PLUGINS=1
-$BUILD_ROOT/embedded-compositor/embedded-compositor &
+# Launch only the compositor with qtvirtualkeyboard input method.
+QT_IM_MODULE=qtvirtualkeyboard $BUILD_ROOT/embedded-compositor/embedded-compositor &
 compositor_pid=$!
 
 
@@ -53,6 +54,11 @@ export QML2_IMPORT_PATH=$BUILD_ROOT/quickembeddedshellwindow
 export LD_LIBRARY_PATH=$BUILD_ROOT/quickembeddedshellwindow/EmbeddedShell:$BUILD_ROOT/embeddedplatform
 
 echo "======  Launching Clients... ======"
+
+# Ensure that no input module (e.g. ibus) is set for our clients.
+# We want Qt Wayland Client to use its built-in zwp_text_input_v2 support.
+unset QT_IM_MODULE
+
 CLIENTS=$BUILD_ROOT/dev-tools/testclients
 
 $CLIENTS/leftclient/leftclient &

--- a/embedded-compositor/embedded-compositor.pro
+++ b/embedded-compositor/embedded-compositor.pro
@@ -1,4 +1,6 @@
 QT += core gui waylandcompositor waylandcompositor-private core-private gui-private quick dbus
+
+QT += virtualkeyboard svg
 CONFIG += c++17 wayland-scanner
 # CONFIG += sanitizer sanitize_address
 

--- a/embedded-compositor/qml.qrc
+++ b/embedded-compositor/qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>qml/DefaultTaskSwitcher/TaskSwitcher.qml</file>
         <file>qml/main.qml</file>
+        <file>qml/Keyboard.qml</file>
         <file>qml/Notifications/Notifications.qml</file>
         <file>qml/Notifications/Notification.qml</file>
         <file>qml/RootTransformer.qml</file>

--- a/embedded-compositor/qml/Keyboard.qml
+++ b/embedded-compositor/qml/Keyboard.qml
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+import QtQuick 2.15
+import QtQuick.VirtualKeyboard 2.0
+
+Item {
+    id: keyboardContainer
+
+    property int contentYTranslate: 0
+    property int keyboardMargin: 50
+
+    // Cannot be a Binding since it would cause a feedback loop between the
+    // translation and the cursor rect changing in response to the translation.
+    function updateTranslate() {
+        const im = Qt.inputMethod;
+        if (im.visible) {
+            const cursorRect = im.cursorRectangle;
+
+            const overlap = -contentYTranslate + cursorRect.y + cursorRect.height - inputPanel.y + keyboardMargin;
+            contentYTranslate = Math.min(0, -overlap);
+        } else {
+            contentYTranslate = 0;
+        }
+    }
+
+    Connections {
+        target: Qt.inputMethod
+        function onCursorRectangleChanged() {
+            keyboardContainer.updateTranslate();
+        }
+    }
+
+    InputPanel {
+        id: inputPanel
+        visible: y < parent.height
+        y: active ? parent.height - height : parent.height
+        anchors.left: parent.left
+        anchors.right: parent.right
+        Behavior on y {
+            NumberAnimation { }
+        }
+        onYChanged: Qt.callLater(keyboardContainer.updateTranslate)
+        onHeightChanged: Qt.callLater(keyboardContainer.updateTranslate)
+        onVisibleChanged: keyboardContainer.updateTranslate()
+    }
+}

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -14,6 +14,9 @@ import "Notifications"
 
 WaylandCompositor {
     objectName: "compositor"
+
+    TextInputManager { }
+
     XdgOutputManagerV1 {
         WaylandOutput {
             objectName: "output"
@@ -82,6 +85,11 @@ WaylandCompositor {
                 anchors.left: leftArea.right
                 anchors.right: rightArea.left
                 anchors.bottom: bottomArea.top
+
+                transform: Translate {
+                    y: keyboardLoader.contentYTranslate
+                }
+
                 border {
                     width: 1
                     color:"red"
@@ -159,6 +167,18 @@ WaylandCompositor {
                 function doSwitch(shellSurface, view)
                 {
                     centerArea.selectSurface(shellSurface, view);
+                }
+            }
+
+            Loader {
+                id: keyboardLoader
+                readonly property int contentYTranslate: item ? item.contentYTranslate : 0
+                source: "Keyboard.qml"
+                anchors.fill: parent
+                onStatusChanged: {
+                    if (status === Loader.Error) {
+                        console.warn("Failed to load virtual keyboard:", sourceComponent.errorString());
+                    }
                 }
             }
 


### PR DESCRIPTION
Using Qt's built-in zwp_text_input_v2 to talk to Wayland clients.

The central view is translated vertically to ensure the cursor in the current text field is not covered by the keyboard.