### PR TITLE
Install relevant headers in /usr/include/

### DIFF
--- a/embeddedplatform/embeddedplatform.pro
+++ b/embeddedplatform/embeddedplatform.pro
@@ -27,6 +27,13 @@ HEADERS += \
 QMAKE_USE += wayland-client
 WAYLANDCLIENTSOURCES += ../protocol/embedded-shell.xml
 
+headers.path = /usr/include/embedded-compositor
+headers.files += embeddedplatform.h
+headers.files += embeddedshellanchor.h
+headers.files += embeddedshellsurface.h
+
+INSTALLS += headers
+
 target.path = /usr/lib
 INSTALLS += target
 

--- a/embeddedplatform/embeddedplatform.pro
+++ b/embeddedplatform/embeddedplatform.pro
@@ -28,9 +28,10 @@ QMAKE_USE += wayland-client
 WAYLANDCLIENTSOURCES += ../protocol/embedded-shell.xml
 
 headers.path = /usr/include/embedded-compositor
-headers.files += embeddedplatform.h
-headers.files += embeddedshellanchor.h
-headers.files += embeddedshellsurface.h
+headers.files += \
+    embeddedplatform.h \
+    embeddedshellanchor.h \
+    embeddedshellsurface.h
 
 INSTALLS += headers
 


### PR DESCRIPTION
To build applications, that use the embeddedplatform the specified headers are required and should be installed in the developer's system.