### PR TITLE
[feature] added sort_index to views dbus parameter

### DIFF
--- a/dbus/de.EmbeddedCompositor.taskswitcher.xml
+++ b/dbus/de.EmbeddedCompositor.taskswitcher.xml
@@ -7,7 +7,7 @@
 <method name="Close"/>
 <property name="currentView" type="s" access="readwrite"/>
 <!-- app id, app label, app icon, view label, view icon, pid, sort index, properties -->
-<property name="views" type="a(ssssssiia{sv})"  access="read" >
+<property name="views" type="a(ssssssuua{sv})"  access="read" >
     <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
 </property>
 </interface>

--- a/dbus/de.EmbeddedCompositor.taskswitcher.xml
+++ b/dbus/de.EmbeddedCompositor.taskswitcher.xml
@@ -6,8 +6,8 @@
 <method name="Open"/>
 <method name="Close"/>
 <property name="currentView" type="s" access="readwrite"/>
-<!-- app id, app label, app icon, view label, view icon, pid, properties -->
-<property name="views" type="a(ssssssia{sv})"  access="read" >
+<!-- app id, app label, app icon, view label, view icon, pid, sort index, properties -->
+<property name="views" type="a(ssssssiia{sv})"  access="read" >
     <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
 </property>
 </interface>

--- a/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
+++ b/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
@@ -60,7 +60,7 @@ void MainWindow::initShell(EmbeddedShellSurface *shellSurface,
   }
   shellSurface->sendAnchor(EmbeddedShellTypes::Anchor::Center);
   auto v1 = shellSurface->createView("View One", "View One", 3);
-  auto v2 = shellSurface->createView("View Two", "View Two", 2);
+  auto v2 = shellSurface->createView("View Two", "View Two", -2);
   auto v3 = shellSurface->createView("View Three", "View Three", 1);
   connect(v1, &EmbeddedShellSurfaceView::selected, this, [=] {
     m_label->setText(v1->label() +

--- a/embedded-compositor/dbusinterface.cpp
+++ b/embedded-compositor/dbusinterface.cpp
@@ -214,7 +214,7 @@ void TaskSwitcherInterface::publishViews() {
         view ? view->label() : "surface",
         view ? view->icon() : QString(),
         uint32_t(surface->getClientPid()),
-        view ? int32_t(view->sortIndex()) : 0,
+        view ? uint32_t(view->sortIndex()) : 0,
         QVariantMap(), //args
     });
   }

--- a/embedded-compositor/dbusinterface.cpp
+++ b/embedded-compositor/dbusinterface.cpp
@@ -146,7 +146,7 @@ const QList<TaskSwitcherEntry> &TaskSwitcherInterface::views() const {
 QDBusArgument &operator<<(QDBusArgument &argument,
                           const TaskSwitcherEntry &entry) {
   argument.beginStructure();
-  argument << entry.uuid << entry.appId << entry.appLabel << entry.appIcon << entry.label << entry.icon << entry.pid << entry.args;
+  argument << entry.uuid << entry.appId << entry.appLabel << entry.appIcon << entry.label << entry.icon << entry.pid << entry.sortIndex << entry.args;
   argument.endStructure();
   return argument;
 }
@@ -154,7 +154,7 @@ QDBusArgument &operator<<(QDBusArgument &argument,
 const QDBusArgument &operator>>(const QDBusArgument &argument,
                                 TaskSwitcherEntry &entry) {
   argument.beginStructure();
-  argument >> entry.uuid >> entry.appId >> entry.appLabel >> entry.appIcon >> entry.label >> entry.icon >> entry.pid >> entry.args;
+  argument >> entry.uuid >> entry.appId >> entry.appLabel >> entry.appIcon >> entry.label >> entry.icon >> entry.pid >> entry.sortIndex >> entry.args;
   argument.endStructure();
   return argument;
 }
@@ -214,6 +214,7 @@ void TaskSwitcherInterface::publishViews() {
         view ? view->label() : "surface",
         view ? view->icon() : QString(),
         uint32_t(surface->getClientPid()),
+        view ? int32_t(view->sortIndex()) : 0,
         QVariantMap(), //args
     });
   }

--- a/embedded-compositor/dbusinterface.h
+++ b/embedded-compositor/dbusinterface.h
@@ -59,7 +59,7 @@ struct TaskSwitcherEntry {
   QString label;
   QString icon;
   uint32_t pid;
-  int32_t sortIndex;
+  uint32_t sortIndex;
   QVariantMap args; // for future extension
 };
 

--- a/embedded-compositor/dbusinterface.h
+++ b/embedded-compositor/dbusinterface.h
@@ -59,6 +59,7 @@ struct TaskSwitcherEntry {
   QString label;
   QString icon;
   uint32_t pid;
+  int32_t sortIndex;
   QVariantMap args; // for future extension
 };
 

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -35,7 +35,7 @@ void EmbeddedShellExtension::initialize() {
 
 void EmbeddedShellExtension::embedded_shell_surface_create(
     Resource *resource, wl_resource *wl_surface, uint32_t id, uint32_t anchor,
-    uint32_t margin, int sort_index) {
+    uint32_t margin, unsigned int sort_index) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << id << "anchor" << anchor
                     << "margin" << margin;
   Q_UNUSED(resource)
@@ -65,7 +65,7 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
                                            QWaylandSurface *surface,
                                            const QWaylandResource &resource,
                                            EmbeddedShellTypes::Anchor anchor,
-                                           uint32_t margin, int32_t sort_index)
+                                           uint32_t margin, uint32_t sort_index)
     : QWaylandShellSurfaceTemplate<EmbeddedShellSurface>(this),
       m_surface(surface), m_anchor(anchor), m_margin(margin),
       m_sort_index(sort_index) {
@@ -89,7 +89,7 @@ void EmbeddedShellSurface::setMargin(int newMargin) {
   emit marginChanged(newMargin);
 }
 
-void EmbeddedShellSurface::setSortIndex(int sort_index) {
+void EmbeddedShellSurface::setSortIndex(unsigned int sort_index) {
   m_sort_index = sort_index;
   emit sortIndexChanged(sort_index);
 }
@@ -149,7 +149,7 @@ void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,
 
 void EmbeddedShellSurface::embedded_shell_surface_view_create(
     Resource *resource, wl_resource *shell_surface, const QString &appId, const QString &appLabel, const QString &appIcon,
-    const QString &label, const QString &icon, int32_t sort_index, uint32_t id) {
+    const QString &label, const QString &icon, uint32_t sort_index, uint32_t id) {
   Q_UNUSED(shell_surface)
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << id;
   auto view = new EmbeddedShellSurfaceView(appId, appLabel, appIcon, label, icon, sort_index,
@@ -160,7 +160,7 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
                                                    const QString &label,
                                                    const QString &icon,
-                                                   int32_t sort_index,
+                                                   uint32_t sort_index,
                                                    wl_client *client,
                                                    int id, int version)
     : QtWaylandServer::surface_view(client, id, version)
@@ -176,7 +176,7 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
                                                    const QString &appIcon,
                                                    const QString &label,
                                                    const QString &icon,
-                                                   int32_t sort_index,
+                                                   uint32_t sort_index,
                                                    wl_client *client,
                                                    int id, int version)
     : QtWaylandServer::surface_view(client, id, version)
@@ -301,15 +301,15 @@ void EmbeddedShellSurface::embedded_shell_surface_set_margin(Resource *resource,
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_sort_index(
-    Resource *resource, int32_t sort_index) {
+    Resource *resource, uint32_t sort_index) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << sort_index;
   Q_UNUSED(resource)
   setSortIndex(sort_index);
 }
 
-int EmbeddedShellSurfaceView::sortIndex() const { return m_sortIndex; }
+unsigned int EmbeddedShellSurfaceView::sortIndex() const { return m_sortIndex; }
 
-void EmbeddedShellSurfaceView::setSortIndex(int newSortIndex) {
+void EmbeddedShellSurfaceView::setSortIndex(unsigned int newSortIndex) {
   if (m_sortIndex == newSortIndex)
     return;
   m_sortIndex = newSortIndex;
@@ -321,7 +321,7 @@ QString EmbeddedShellSurfaceView::getUuid() const {
 }
 
 void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
-                                                           int32_t sort_index) {
+                                                           uint32_t sort_index) {
   Q_UNUSED(resource)
   setSortIndex(sort_index);
 }

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -36,7 +36,7 @@ public:
   void embedded_shell_surface_create(Resource *resource,
                                      struct ::wl_resource *surface, uint32_t id,
                                      uint32_t anchor, uint32_t margin,
-                                     int sort_index) override;
+                                     uint sort_index) override;
 
   void initialize() override;
 signals:
@@ -51,7 +51,7 @@ public:
   EmbeddedShellSurface(EmbeddedShellExtension *ext, QWaylandSurface *surface,
                        const QWaylandResource &resource,
                        EmbeddedShellTypes::Anchor anchor, uint32_t margin,
-                       int32_t sort_index);
+                       uint32_t sort_index);
   QWaylandQuickShellIntegration *
   createIntegration(QWaylandQuickShellSurfaceItem *item) override;
 
@@ -59,16 +59,16 @@ public:
 
   EmbeddedShellTypes::Anchor getAnchor() { return m_anchor; }
   int getMargin() { return m_margin; }
-  int sortIndex() { return m_sort_index; }
+  unsigned int sortIndex() { return m_sort_index; }
   Q_PROPERTY(
       EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
-  Q_PROPERTY(int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 
   void setAnchor(embedded_shell_anchor_border newAnchor);
   void setMargin(int newMargin);
-  void setSortIndex(int sort_index);
+  void setSortIndex(unsigned int sort_index);
   Q_INVOKABLE void sendConfigure(const QSize size);
   QString getUuid() const;
   pid_t getClientPid() const;
@@ -76,14 +76,14 @@ public:
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
-  void sortIndexChanged(int sort_index);
+  void sortIndexChanged(unsigned int sort_index);
   void createView(EmbeddedShellSurfaceView *view);
 
 private:
   QWaylandSurface *m_surface;
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
-  int32_t m_sort_index = 0;
+  uint32_t m_sort_index = 0;
   QUuid m_uuid = QUuid::createUuid();
 
   // embedded_shell_surface interface
@@ -93,12 +93,12 @@ protected:
   void embedded_shell_surface_view_create(Resource *resource,
                                           wl_resource *shell_surface,
                                           const QString &appId, const QString &appLabel, const QString &appIcon,
-                                          const QString &label, const QString &icon, int sort_index,
+                                          const QString &label, const QString &icon, unsigned int sort_index,
                                           uint32_t id) override;
   void embedded_shell_surface_set_margin(Resource *resource,
                                          int32_t margin) override;
   void embedded_shell_surface_set_sort_index(Resource *resource,
-                                             int32_t sort_index) override;
+                                             uint32_t sort_index) override;
 };
 
 class EmbeddedShellSurfaceView : public QObject,
@@ -109,13 +109,13 @@ class EmbeddedShellSurfaceView : public QObject,
   Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
-  Q_PROPERTY(int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 public:
   EmbeddedShellSurfaceView(const QString &appId, const QString &label, const QString &icon,
-                           int32_t sort_index, wl_client *client, int id, int version);
+                           uint32_t sort_index, wl_client *client, int id, int version);
   EmbeddedShellSurfaceView(const QString &appId, const QString &appLabel, const QString &appIcon,
-                           const QString &label, const QString &icon, int32_t sort_index,
+                           const QString &label, const QString &icon, uint32_t sort_index,
                            wl_client *client, int id, int version);
 
   QString appId() const;
@@ -138,15 +138,15 @@ public:
   void setIcon(const QString &icon);
   Q_SIGNAL void iconChanged(const QString &icon);
 
-  int sortIndex() const;
-  void setSortIndex(int newSortIndex);
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int newSortIndex);
 
   QString getUuid() const;
 
 public slots:
   void select() { surface_view::send_selected(); }
 signals:
-  void sortIndexChanged(int index);
+  void sortIndexChanged(unsigned int index);
 
 protected:
   void surface_view_set_app_label(Resource *resource, const QString &label) override;
@@ -154,7 +154,7 @@ protected:
   void surface_view_set_label(Resource *resource, const QString &text) override;
   void surface_view_set_icon(Resource *resource, const QString &icon) override;
   void surface_view_set_sort_index(Resource *resource,
-                                   int32_t sort_index) override;
+                                   uint32_t sort_index) override;
 
 private:
   QUuid m_uuid = QUuid::createUuid();
@@ -163,7 +163,7 @@ private:
   QString m_appIcon;
   QString m_label;
   QString m_icon;
-  int32_t m_sortIndex = 0;
+  uint32_t m_sortIndex = 0;
 };
 
 class QuickEmbeddedShellIntegration : public QWaylandQuickShellIntegration {

--- a/embeddedplatform/embeddedshell.cpp
+++ b/embeddedplatform/embeddedshell.cpp
@@ -15,7 +15,7 @@ EmbeddedShell::EmbeddedShell()
 EmbeddedShellSurface *
 EmbeddedShell::createSurface(QtWaylandClient::QWaylandWindow *window,
                              EmbeddedShellTypes::Anchor anchor, uint32_t margin,
-                             int sort_index) {
+                             unsigned int sort_index) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << isActive() << anchor << margin;
   if (!isActive())
     return nullptr;

--- a/embeddedplatform/embeddedshell.h
+++ b/embeddedplatform/embeddedshell.h
@@ -28,7 +28,7 @@ public:
   EmbeddedShell();
   EmbeddedShellSurface *createSurface(QtWaylandClient::QWaylandWindow *window,
                                       EmbeddedShellTypes::Anchor anchor,
-                                      uint32_t margin, int sort_index);
+                                      uint32_t margin, unsigned int sort_index);
   const struct wl_interface *extensionInterface() const override;
   void bind(struct ::wl_registry *registry, int id, int ver) override;
 };

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -9,7 +9,7 @@
 EmbeddedShellSurface::EmbeddedShellSurface(
     struct ::embedded_shell_surface *shell_surface,
     QtWaylandClient::QWaylandWindow *window, EmbeddedShellTypes::Anchor anchor,
-    uint32_t margin, int32_t sort_index)
+    uint32_t margin, uint32_t sort_index)
     : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface, window, anchor,
                                             margin, sort_index)) {}
 
@@ -18,7 +18,7 @@ EmbeddedShellSurface::~EmbeddedShellSurface() {}
 EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(
     struct ::embedded_shell_surface *shell_surface,
     QtWaylandClient::QWaylandWindow *window, EmbeddedShellTypes::Anchor anchor,
-    uint32_t margin, int32_t sort_index)
+    uint32_t margin, uint32_t sort_index)
     : QWaylandShellSurface(window), QtWayland::embedded_shell_surface(
                                         shell_surface),
       m_anchor(anchor), m_margin(margin), m_sort_index(sort_index) {}
@@ -30,7 +30,7 @@ EmbeddedShellTypes::Anchor EmbeddedShellSurface::getAnchor() const {
   return d->m_anchor;
 }
 
-int EmbeddedShellSurface::getSortIndex() const {
+unsigned int EmbeddedShellSurface::getSortIndex() const {
   Q_D(const EmbeddedShellSurface);
   return d->m_sort_index;
 }
@@ -47,7 +47,7 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_configure(
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
-                                                           int32_t sort_index)
+                                                           uint32_t sort_index)
 {
     return createView(QString(), QString(), QString(), label, icon, sort_index);
 }
@@ -55,7 +55,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            const QString &label,
                                                            const QString &icon,
-                                                           int32_t sort_index)
+                                                           uint32_t sort_index)
 {
     return createView(appId, QString(), QString(), label, icon, sort_index);
 }
@@ -65,7 +65,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            const QString &appIcon,
                                                            const QString &label,
                                                            const QString &icon,
-                                                           int32_t sort_index)
+                                                           uint32_t sort_index)
 {
   Q_D(EmbeddedShellSurface);
   auto view =
@@ -88,7 +88,7 @@ void EmbeddedShellSurface::sendMargin(int margin) {
   d->set_margin(margin);
 }
 
-void EmbeddedShellSurface::sendSortIndex(int sortIndex) {
+void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex) {
   Q_D(EmbeddedShellSurface);
   d->set_sort_index(sortIndex);
 }

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -28,24 +28,24 @@ public:
   EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
                        QtWaylandClient::QWaylandWindow *window,
                        EmbeddedShellTypes::Anchor anchor, uint32_t margin,
-                       int32_t sort_index);
+                       uint32_t sort_index);
   ~EmbeddedShellSurface() override;
 
   EmbeddedShellTypes::Anchor getAnchor() const;
-  int getSortIndex() const;
+  unsigned int getSortIndex() const;
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
-                                       int32_t sort_index);
+                                       uint32_t sort_index);
   EmbeddedShellSurfaceView *createView(const QString &appId,
                                        const QString &label,
                                        const QString &icon,
-                                       int32_t sort_index);
+                                       uint32_t sort_index);
   EmbeddedShellSurfaceView *createView(const QString &appId,
                                        const QString &appLabel,
                                        const QString &appIcon,
                                        const QString &label,
                                        const QString &icon,
-                                       int32_t sort_index);
+                                       uint32_t sort_index);
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();
 signals:
@@ -53,7 +53,7 @@ signals:
 public slots:
   void sendAnchor(EmbeddedShellTypes::Anchor anchor);
   void sendMargin(int margin);
-  void sendSortIndex(int sortIndex);
+  void sendSortIndex(unsigned int sortIndex);
 };
 
 class EmbeddedShellSurfaceView : public QObject {

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -17,7 +17,7 @@ public:
   EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
                               QtWaylandClient::QWaylandWindow *window,
                               EmbeddedShellTypes::Anchor anchor,
-                              uint32_t margin, int32_t sort_index);
+                              uint32_t margin, uint32_t sort_index);
   ~EmbeddedShellSurfacePrivate() override;
   EmbeddedShellTypes::Anchor getAnchor() const { return m_anchor; }
   uint32_t getMargin() const { return m_margin; }
@@ -27,7 +27,7 @@ public:
 private:
   EmbeddedShellTypes::Anchor m_anchor;
   uint32_t m_margin = 0;
-  int32_t m_sort_index = 0;
+  uint32_t m_sort_index = 0;
   QSize m_pendingSize = {0, 0};
   EmbeddedShellSurface *q_ptr = nullptr;
 

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -10,7 +10,7 @@
 			<arg name="anchor" type="uint" />
 		</request>
 		<request name="set_sort_index">
-			<arg name="sort_index" type="int" />
+			<arg name="sort_index" type="uint" />
 		</request>
 		<request name="set_margin">
 			<arg name="margin" type="int" />
@@ -40,7 +40,7 @@
 			<arg name="app_icon" type="string" summary="The icon name of the application"/>
 			<arg name="label" type="string" summary="The user-visible label for this particular view"/>
 			<arg name="icon" type="string" summary="The icon name of this particular view"/>
-			<arg name="sort_index" type="int" />
+			<arg name="sort_index" type="uint" />
 			<arg name="new_view_id" type="new_id" interface="surface_view" />
 		</request>
 	</interface>
@@ -51,7 +51,7 @@
 			<arg name="new_shellsurface_id" type="new_id" interface="embedded_shell_surface" />
 			<arg name="anchor" type="uint" />
 			<arg name="margin" type="uint" />
-			<arg name="sort_index" type="int" />
+			<arg name="sort_index" type="uint" />
 		</request>
 
 		<enum name="error">
@@ -86,7 +86,7 @@
 			<arg name="text" type="string" />
 		</request>
 		<request name="set_sort_index">
-			<arg name="sort_index" type="int" />
+			<arg name="sort_index" type="uint" />
 		</request>
 		<event name="selected"></event>
 		<request name="destroy" type="destructor"></request>

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -28,7 +28,7 @@ void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor) {
 EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &appId,
                                                                const QString &appLabel,
                                                                const QString &label,
-                                                               int sort_index) {
+                                                               unsigned int sort_index) {
   auto view = m_surface->createView(appId, appLabel, label, sort_index);
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
   return view;
@@ -61,9 +61,9 @@ void QuickEmbeddedShellWindow::setMargin(int newMargin) {
   emit marginChanged(newMargin);
 }
 
-int QuickEmbeddedShellWindow::sortIndex() const { return m_sortIndex; }
+unsigned int QuickEmbeddedShellWindow::sortIndex() const { return m_sortIndex; }
 
-void QuickEmbeddedShellWindow::setSortIndex(int sortIndex) {
+void QuickEmbeddedShellWindow::setSortIndex(unsigned int sortIndex) {
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
   if (m_sortIndex == sortIndex)
     return;

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -27,7 +27,7 @@ public:
                  NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
   Q_PROPERTY(
-      int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+     unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
 
   EmbeddedShellTypes::Anchor anchor() const;
   void setAnchor(EmbeddedShellTypes::Anchor newAnchor);
@@ -38,22 +38,22 @@ public:
 
   int margin() const;
   void setMargin(int newMargin);
-  int sortIndex() const;
-  void setSortIndex(int sortIndex);
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int sortIndex);
 
 public slots:
-  EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, int sort_index);
+  EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, unsigned int sort_index);
 
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
-  void sortIndexChanged(int sortIndex);
+  void sortIndexChanged(unsigned int sortIndex);
 
 private:
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   EmbeddedShellSurface *m_surface = nullptr;
   int m_margin = -1;
-  int m_sortIndex = 0;
+  unsigned int m_sortIndex = 0;
 };
 
 #endif // QUICKEMBEDDEDSHELLWINDOW_H

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -52,12 +52,12 @@ EmbeddedShellIntegration::createShellSurface(
   if (prop.isValid())
     margin = prop.toUInt();
 
-  int32_t sort_index = 0;
+  uint32_t sort_index = 0;
 
   auto env_sort_index = qgetenv("EMBEDDED_SHELL_SORT_INDEX");
   if (!env_sort_index.isNull()) {
     bool ok = false;
-    sort_index = env_sort_index.toInt(&ok);
+    sort_index = env_sort_index.toUInt(&ok);
     if (!ok) {
       qWarning() << "failed to read sort index from EMBEDDED_SORT_INDEX:"
                  << env_sort_index << "is not an integer";
@@ -66,7 +66,7 @@ EmbeddedShellIntegration::createShellSurface(
 
   prop = window->window()->property("sortIndex");
   if (prop.isValid())
-    sort_index = prop.toInt();
+    sort_index = prop.toUInt();
 
   auto ess = m_shell->createSurface(window, anchor, margin, sort_index);
 


### PR DESCRIPTION
Added `sort_index` to the informations of the `views` dbus-request. That allows it in combination with `appId` to identify  for a non-volatile identification of a view.