### PR TITLE
Update taskSwitcher currentView when selecting a view

### DIFF
--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -116,6 +116,7 @@ WaylandCompositor {
                         if(window.shellSurface === shellSurface) {
                             window.currentView = view;
                             surfaceItem = window;
+                            taskSwitcherInterface.currentView = surfaceItem.uuid;
                             break;
                         }
                     }


### PR DESCRIPTION
Currently, this is only done when the surfaceItem changes. However, the surfaceItem.uuid returns either its current view uuid, or the surfaceItem uuid but taskSwitcher's currentView is updated programmatically only.

If a view is selected on the same surfaceItem, the code path to update the currentView is never hit as the surfaceItem didn't change, resulting in an incorrect currentView.

This can be observed in the widgetcenterclient which opens a main window that gets a "default" view from the embedded shell integration but then registers three additional views. Here the main window UUID remains as currentView despite the compositor switching to View 1 when it arrives.