### PR TITLE
Keyboard: Use State for keyboard animation

### DIFF
--- a/embedded-compositor/qml/Keyboard.qml
+++ b/embedded-compositor/qml/Keyboard.qml
@@ -33,14 +33,37 @@ Item {
     InputPanel {
         id: inputPanel
         visible: y < parent.height
-        y: active ? parent.height - height : parent.height
         anchors.left: parent.left
         anchors.right: parent.right
-        Behavior on y {
-            NumberAnimation { }
-        }
         onYChanged: Qt.callLater(keyboardContainer.updateTranslate)
         onHeightChanged: Qt.callLater(keyboardContainer.updateTranslate)
         onVisibleChanged: keyboardContainer.updateTranslate()
+
+        states: [
+            State {
+                name: "VISIBLE"
+                when: inputPanel.active
+                PropertyChanges {
+                    target: inputPanel
+                    y: inputPanel.parent.height - inputPanel.height
+                }
+            },
+            State {
+                name: "HIDDEN"
+                when: !inputPanel.active
+                PropertyChanges {
+                    target: inputPanel
+                    y: inputPanel.parent.height
+                }
+            }
+        ]
+
+        transitions: [
+            Transition {
+                NumberAnimation {
+                    property: "y"
+                }
+            }
+        ]
     }
 }

--- a/embedded-compositor/qml/Keyboard.qml
+++ b/embedded-compositor/qml/Keyboard.qml
@@ -38,11 +38,11 @@ Item {
         onYChanged: Qt.callLater(keyboardContainer.updateTranslate)
         onHeightChanged: Qt.callLater(keyboardContainer.updateTranslate)
         onVisibleChanged: keyboardContainer.updateTranslate()
+        state: inputPanel.active ? "VISIBLE": "HIDDEN"
 
         states: [
             State {
                 name: "VISIBLE"
-                when: inputPanel.active
                 PropertyChanges {
                     target: inputPanel
                     y: inputPanel.parent.height - inputPanel.height
@@ -50,7 +50,6 @@ Item {
             },
             State {
                 name: "HIDDEN"
-                when: !inputPanel.active
                 PropertyChanges {
                     target: inputPanel
                     y: inputPanel.parent.height


### PR DESCRIPTION
This PR extends the PR #36 of @basyskom-broulik and therefore replaced it . There was a missing init state.

> Merely animating the y property can cause the keyboard to be visible when screen size changes or on application startup since the keyboard will fly to the new position.
>
> Instead, use an explicit State for visible and hidden and make use of Transitions. This way the animation occurs only during a state change from hidden to visible and vice-versa but never if the position changes by other means.

