### PR TITLE
QuickEmbeddedShellWindow: Create view function with all available parameters

### DIFF
--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -34,6 +34,12 @@ EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &ap
   return view;
 }
 
+EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& appId, const QString& appLabel, const QString& appIcon, const QString& label, const QString& icon, uint32_t sort_index){
+    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
+    return view;
+}
+
 void QuickEmbeddedShellWindow::classBegin() {
   qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -43,6 +43,12 @@ public:
 
 public slots:
   EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, unsigned int sort_index);
+  EmbeddedShellSurfaceView *createView(const QString &appId,
+                                       const QString &appLabel,
+                                       const QString &appIcon,
+                                       const QString &label,
+                                       const QString &icon,
+                                       uint32_t sort_index);
 
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);


### PR DESCRIPTION
This chnage is necessary to create a view with a `appIcon` for a EmbeddedShellWindow