### PR TITLE
embeddedshellsurface: Call destroy in destructor

### DIFF
--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -98,6 +98,10 @@ EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(
     EmbeddedShellSurface *surf, const QString &label)
     : QObject(surf), QtWayland::surface_view(view), m_label(label), q_ptr(q) {}
 
+EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate() {
+  destroy();
+}
+
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
                                                    EmbeddedShellSurface *surf,
                                                    const QString &label)

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -46,6 +46,7 @@ public:
                                   ::surface_view *view,
                                   EmbeddedShellSurface *surf,
                                   const QString &label);
+  ~EmbeddedShellSurfaceViewPrivate() override;
   void surface_view_selected() override {
     qDebug() << __PRETTY_FUNCTION__;
     Q_Q(EmbeddedShellSurfaceView);


### PR DESCRIPTION
Ensures the Wayland resource is also destroyed.

Otherwise it can happen that a wayland event, such as "selected" arrives, which then tries to call into us when we're already destroyed and crash.