### PR TITLE
Add full-screen mode via a dbus property 

### DIFF
--- a/dbus/de.EmbeddedCompositor.screen.xml
+++ b/dbus/de.EmbeddedCompositor.screen.xml
@@ -3,6 +3,7 @@
 <node>
 <interface name="de.EmbeddedCompositor.screen">
 <property name="orientation" type="s" access="readwrite"/>
+<property name="fullScreen" type="b" access="readwrite"/>
 <property name="screenSaverActive" type="b" access="read"/>
 <property name="screenSaverEnabled" type="b" access="readwrite"/>
 <property name="screenSaverTimeoutSeconds" type="i" access="readwrite"/>

--- a/embedded-compositor/dbus/CompositorScreenDBusInterface.cpp
+++ b/embedded-compositor/dbus/CompositorScreenDBusInterface.cpp
@@ -24,8 +24,6 @@ void CompositorScreenDBusInterface::setOrientation(const QString &orientation)
     }
 }
 
-
-
 bool CompositorScreenDBusInterface::screenSaverActive() const
 {
     return m_screenSaverActive;
@@ -71,4 +69,17 @@ void CompositorScreenDBusInterface::setScreenSaverTimeoutSeconds(
         return;
     m_screenSaverTimeoutSeconds = newScreenSaverTimeoutSeconds;
     emit screenSaverTimeoutSecondsChanged(m_screenSaverTimeoutSeconds);
+}
+
+void CompositorScreenDBusInterface::setFullScreen(bool value)
+{
+    if (m_fullScreen == value)
+        return;
+    m_fullScreen = value;
+    emit fullScreenChanged(m_fullScreen);
+}
+
+bool CompositorScreenDBusInterface::fullScreen() const
+{
+    return m_fullScreen;
 }

--- a/embedded-compositor/dbus/CompositorScreenDBusInterface.hpp
+++ b/embedded-compositor/dbus/CompositorScreenDBusInterface.hpp
@@ -21,6 +21,8 @@ class CompositorScreenDBusInterface : public DBusInterface
     Q_PROPERTY(
         int screenSaverTimeoutSeconds READ screenSaverTimeoutSeconds WRITE
             setScreenSaverTimeoutSeconds NOTIFY screenSaverTimeoutSecondsChanged)
+    Q_PROPERTY(bool fullScreen READ fullScreen WRITE setFullScreen
+                   NOTIFY fullScreenChanged)
 
 public:
     explicit CompositorScreenDBusInterface(QObject *parent = nullptr);
@@ -38,6 +40,8 @@ public:
 
     int screenSaverTimeoutSeconds() const;
     void setScreenSaverTimeoutSeconds(int newScreenSaverTimeoutSeconds);
+    bool fullScreen() const;
+    void setFullScreen(bool fullScreen);
 
 signals:
     void orientationChanged(const QString &orientation);
@@ -45,9 +49,11 @@ signals:
     void showScreenSaver();
     void screenSaverEnabledChanged(bool screenSaverEnabled);
     void screenSaverTimeoutSecondsChanged(int screenSaverTimeoutSeconds);
+    void fullScreenChanged(bool fullScreen);
 
 private:
     QString m_orientation = QStringLiteral("0");
+    bool m_fullScreen;
     bool m_screenSaverActive;
     bool m_screenSaverEnabled;
     int m_screenSaverTimeoutSeconds;

--- a/embedded-compositor/qml/RootTransformer.qml
+++ b/embedded-compositor/qml/RootTransformer.qml
@@ -12,6 +12,7 @@ import "Notifications"
 
 Item {
     id: rootTransformItem
+    property bool fullScreen: false
 
     states: [
         State {

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -58,6 +58,7 @@ WaylandCompositor {
         RootTransformer {
             id: rootTransformItem
             state: dbusScreenInterface.orientation
+            fullScreen: dbusScreenInterface.fullScreen
 
             Item {
                 Keys.onPressed:
@@ -82,10 +83,10 @@ WaylandCompositor {
 
             Rectangle {
                 id: centerArea
-                anchors.top: topArea.bottom
-                anchors.left: leftArea.right
-                anchors.right: rightArea.left
-                anchors.bottom: bottomArea.top
+                anchors.top: !rootTransformItem.fullScreen ? topArea.bottom : rootTransformItem.top
+                anchors.left: !rootTransformItem.fullScreen ? leftArea.right : rootTransformItem.left
+                anchors.right: !rootTransformItem.fullScreen ? rightArea.left : rootTransformItem.right
+                anchors.bottom: !rootTransformItem.fullScreen ? bottomArea.top : rootTransformItem.bottom
 
                 transform: Translate {
                     y: keyboardLoader.contentYTranslate
@@ -130,6 +131,7 @@ WaylandCompositor {
                 anchors.left: parent.left
                 anchors.top: topArea.bottom
                 property Item surfaceItem
+                visible: !rootTransformItem.fullScreen
             }
             Item {
                 id:rightArea
@@ -138,6 +140,7 @@ WaylandCompositor {
                 anchors.right: parent.right
                 anchors.top: topArea.bottom
                 property Item surfaceItem
+                visible: !rootTransformItem.fullScreen
             }
             Item {
                 id: topArea
@@ -146,6 +149,7 @@ WaylandCompositor {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 property Item surfaceItem
+                visible: !rootTransformItem.fullScreen
             }
             Item {
                 id: bottomArea
@@ -154,6 +158,7 @@ WaylandCompositor {
                 anchors.left: parent.left
                 anchors.right: parent.right
                 property Item surfaceItem
+                visible: !rootTransformItem.fullScreen
             }
 
             Loader {
@@ -388,6 +393,7 @@ WaylandCompositor {
         screenSaverEnabled: configuration.screenSaverEnabled
         screenSaverTimeoutSeconds: configuration.screenSaverTimeoutSeconds
         orientation: configuration.screenOrientation
+        fullScreen: configuration.fullScreen
     }
 
     ConfigurationHive {
@@ -408,5 +414,6 @@ WaylandCompositor {
         property real screenPhysicalHeight: 137
         // compositor controlled rotation, i.e. "0", "90", "180", "270"
         property string screenOrientation: "0"
+        property bool fullScreen: false
     }
 }


### PR DESCRIPTION
This change allows you to request the full screen, it means the left,right,top,bottom sidebars are hidden by sending the request via DBUS ->
`dbus-send --system --print-reply --dest=de.jumo.EmbeddedCompositor /screen org.freedesktop.DBus.Properties.Set string:de.EmbeddedCompositor.screen string:fullScreen variant:boolean:true`

If you set the property to `false` the previously views are visible again.