### PR TITLE
Introduce implicit size concept for surfaces

### DIFF
--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -67,7 +67,7 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
                                            EmbeddedShellTypes::Anchor anchor,
                                            uint32_t margin, uint32_t sort_index)
     : QWaylandShellSurfaceTemplate<EmbeddedShellSurface>(this),
-      m_surface(surface), m_anchor(anchor), m_margin(margin),
+      m_surface(surface), m_size(QSize{0, 0}), m_anchor(anchor), m_margin(margin),
       m_sort_index(sort_index) {
   Q_UNUSED(ext)
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << anchor
@@ -81,6 +81,14 @@ QWaylandQuickShellIntegration *
 EmbeddedShellSurface::createIntegration(QWaylandQuickShellSurfaceItem *item) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__;
   return new QuickEmbeddedShellIntegration(item);
+}
+
+void EmbeddedShellSurface::setSize(const QSize &size) {
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << m_size << "->" << size;
+    if (m_size != size) {
+        m_size = size;
+        Q_EMIT sizeChanged(size);
+    }
 }
 
 void EmbeddedShellSurface::setMargin(int newMargin) {
@@ -134,6 +142,13 @@ void QuickEmbeddedShellIntegration::sendConfigure(const QSize size) {
 void QuickEmbeddedShellIntegration::handleEmbeddedShellSurfaceDestroyed() {
   qCDebug(shellExt) << __PRETTY_FUNCTION__;
   m_shellSurface = nullptr;
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_size(Resource *resource,
+                                                           uint32_t width,
+                                                           uint32_t height) {
+    Q_UNUSED(resource)
+    setSize(QSize(width, height));
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -57,15 +57,18 @@ public:
 
   QWaylandSurface *surface() const { return m_surface; }
 
+  QSize getSize() const { return m_size; }
   EmbeddedShellTypes::Anchor getAnchor() { return m_anchor; }
   int getMargin() { return m_margin; }
   unsigned int sortIndex() { return m_sort_index; }
+  Q_PROPERTY(QSize size READ getSize NOTIFY sizeChanged)
   Q_PROPERTY(
       EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 
+  void setSize(const QSize &size);
   void setAnchor(embedded_shell_anchor_border newAnchor);
   void setMargin(int newMargin);
   void setSortIndex(unsigned int sort_index);
@@ -74,6 +77,7 @@ public:
   pid_t getClientPid() const;
 
 signals:
+  void sizeChanged(const QSize &size);
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sort_index);
@@ -81,6 +85,7 @@ signals:
 
 private:
   QWaylandSurface *m_surface;
+  QSize m_size;
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
@@ -88,6 +93,9 @@ private:
 
   // embedded_shell_surface interface
 protected:
+  void embedded_shell_surface_set_size(Resource *resource,
+                                       uint32_t width,
+                                       uint32_t height) override;
   void embedded_shell_surface_set_anchor(Resource *resource,
                                          uint32_t anchor) override;
   void embedded_shell_surface_view_create(Resource *resource,

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -315,8 +315,8 @@ WaylandCompositor {
             visible: parent.surfaceItem === shellSurfaceItem
 
             onSurfaceDestroyed:  destroy()
-            onWidthChanged: handleResized()
-            onHeightChanged: handleResized()
+            onWidthChanged: Qt.callLater(handleResized)
+            onHeightChanged: Qt.callLater(handleResized)
             Component.onCompleted: {
                 handleAnchor();
             }
@@ -335,7 +335,7 @@ WaylandCompositor {
                 }
 
                 function onSizeChanged(size) {
-                    handleResized();
+                    Qt.callLater(handleResized);
                 }
 
                 function onCreateView(view) {

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -83,6 +83,7 @@ WaylandCompositor {
 
             Rectangle {
                 id: centerArea
+                objectName: "centerArea"
                 anchors.top: !rootTransformItem.fullScreen ? topArea.bottom : rootTransformItem.top
                 anchors.left: !rootTransformItem.fullScreen ? leftArea.right : rootTransformItem.left
                 anchors.right: !rootTransformItem.fullScreen ? rightArea.left : rootTransformItem.right
@@ -126,6 +127,7 @@ WaylandCompositor {
             }
             Item {
                 id:leftArea
+                objectName: "leftArea"
                 width: surfaceItem ? surfaceItem.margin:window.initialSize
                 anchors.bottom: bottomArea.top
                 anchors.left: parent.left
@@ -135,6 +137,7 @@ WaylandCompositor {
             }
             Item {
                 id:rightArea
+                objectName: "rightArea"
                 width: surfaceItem ? surfaceItem.margin :window.initialSize
                 anchors.bottom:bottomArea.top
                 anchors.right: parent.right
@@ -144,6 +147,7 @@ WaylandCompositor {
             }
             Item {
                 id: topArea
+                objectName: "topArea"
                 height: surfaceItem ? surfaceItem.margin : window.initialSize
                 anchors.top: parent.top
                 anchors.left: parent.left
@@ -153,6 +157,7 @@ WaylandCompositor {
             }
             Item {
                 id: bottomArea
+                objectName: "bottomArea"
                 height: surfaceItem ? surfaceItem.margin : window.initialSize
                 anchors.bottom: parent.bottom
                 anchors.left: parent.left
@@ -212,6 +217,7 @@ WaylandCompositor {
         }
         Item {
             id: limboArea
+            objectName: "limboArea"
             visible: false
         }
     }

--- a/embeddedplatform/embeddedshell.cpp
+++ b/embeddedplatform/embeddedshell.cpp
@@ -22,8 +22,9 @@ EmbeddedShell::createSurface(QtWaylandClient::QWaylandWindow *window,
   auto surface = instance->surface_create(
       window->wlSurface(), static_cast<embedded_shell_anchor_border>(anchor),
       margin, sort_index);
+  const QSize size{0, 0};
   auto ess =
-      new EmbeddedShellSurface(surface, window, anchor, margin, sort_index);
+      new EmbeddedShellSurface(surface, window, size, anchor, margin, sort_index);
   return ess;
 }
 

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -8,22 +8,27 @@
 
 EmbeddedShellSurface::EmbeddedShellSurface(
     struct ::embedded_shell_surface *shell_surface,
-    QtWaylandClient::QWaylandWindow *window, EmbeddedShellTypes::Anchor anchor,
+    QtWaylandClient::QWaylandWindow *window, const QSize &size, EmbeddedShellTypes::Anchor anchor,
     uint32_t margin, uint32_t sort_index)
-    : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface, window, anchor,
+    : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface, window, size, anchor,
                                             margin, sort_index)) {}
 
 EmbeddedShellSurface::~EmbeddedShellSurface() {}
 
 EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(
     struct ::embedded_shell_surface *shell_surface,
-    QtWaylandClient::QWaylandWindow *window, EmbeddedShellTypes::Anchor anchor,
+    QtWaylandClient::QWaylandWindow *window, const QSize &size, EmbeddedShellTypes::Anchor anchor,
     uint32_t margin, uint32_t sort_index)
     : QWaylandShellSurface(window), QtWayland::embedded_shell_surface(
                                         shell_surface),
-      m_anchor(anchor), m_margin(margin), m_sort_index(sort_index) {}
+      m_size(size), m_anchor(anchor), m_margin(margin), m_sort_index(sort_index) {}
 
 EmbeddedShellSurfacePrivate::~EmbeddedShellSurfacePrivate() {}
+
+QSize EmbeddedShellSurface::getSize() const {
+  Q_D(const EmbeddedShellSurface);
+  return d->m_size;
+}
 
 EmbeddedShellTypes::Anchor EmbeddedShellSurface::getAnchor() const {
   Q_D(const EmbeddedShellSurface);
@@ -76,6 +81,12 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
 
 QtWaylandClient::QWaylandShellSurface *EmbeddedShellSurface::shellSurface() {
   return d_ptr.data();
+}
+
+void EmbeddedShellSurface::sendSize(const QSize &size) {
+  Q_D(EmbeddedShellSurface);
+  // Check version here if it were versioned.
+  d->set_size(size.width(), size.height());
 }
 
 void EmbeddedShellSurface::sendAnchor(EmbeddedShellTypes::Anchor anchor) {

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -27,10 +27,12 @@ class Q_DECL_EXPORT EmbeddedShellSurface : public QObject {
 public:
   EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
                        QtWaylandClient::QWaylandWindow *window,
+                       const QSize &size,
                        EmbeddedShellTypes::Anchor anchor, uint32_t margin,
                        uint32_t sort_index);
   ~EmbeddedShellSurface() override;
 
+  QSize getSize() const;
   EmbeddedShellTypes::Anchor getAnchor() const;
   unsigned int getSortIndex() const;
   EmbeddedShellSurfaceView *createView(const QString &label,
@@ -51,6 +53,7 @@ public:
 signals:
 
 public slots:
+  void sendSize(const QSize &size);
   void sendAnchor(EmbeddedShellTypes::Anchor anchor);
   void sendMargin(int margin);
   void sendSortIndex(unsigned int sortIndex);

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -16,15 +16,18 @@ class EmbeddedShellSurfacePrivate
 public:
   EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
                               QtWaylandClient::QWaylandWindow *window,
+                              const QSize &size,
                               EmbeddedShellTypes::Anchor anchor,
                               uint32_t margin, uint32_t sort_index);
   ~EmbeddedShellSurfacePrivate() override;
+  QSize getSize() const { return m_size; }
   EmbeddedShellTypes::Anchor getAnchor() const { return m_anchor; }
   uint32_t getMargin() const { return m_margin; }
 
   void applyConfigure() override;
 
 private:
+  QSize m_size;
   EmbeddedShellTypes::Anchor m_anchor;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -16,6 +16,18 @@
 			<arg name="margin" type="int" />
 		</request>
 
+		<request name="set_size"><!-- TODO should probably be since="2" -->
+			<description summary="Sets the size of the surface">
+				Sets the size of the surface in surface-local coordinates. The compositor will display the surface
+				with respect to its anchors.
+
+				If you pass 0 for either value, the compositor will assign it and inform you of the assignment in the
+				configure event. You must set your anchor to opposite edges in the dimensions you omit.
+			</description>
+			<arg name="width" type="uint" />
+			<arg name="height" type="uint" />
+		</request>
+
 		<event name="configure">
 			<description summary="suggest resize">
 	    The configure event asks the client to resize its surface.

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -6,7 +6,8 @@
 Q_LOGGING_CATEGORY(quickShell, "embeddedshell.quick")
 
 QuickEmbeddedShellWindow::QuickEmbeddedShellWindow(QWindow *parent)
-    : QQuickWindow(parent) {
+    : QQuickWindow(parent)
+    , m_size(QSize{0, 0}) {
   qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }
 
@@ -50,8 +51,48 @@ void QuickEmbeddedShellWindow::componentComplete() {
   if (m_surface != nullptr) {
     m_surface->sendAnchor(m_anchor);
     m_surface->sendMargin(m_margin);
+    if (m_size.isValid()) {
+      m_surface->sendSize(m_size);
+    }
   }
+  m_componentComplete = true;
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_surface;
+}
+
+int QuickEmbeddedShellWindow::implicitWidth() const {
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.width();
+  return m_size.width();
+}
+
+void QuickEmbeddedShellWindow::setImplicitWidth(int implicitWidth) {
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitWidth;
+  const QSize newSize{implicitWidth, m_size.height()};
+  if (m_size == newSize) {
+    return;
+  }
+  m_size = newSize;
+  Q_EMIT implicitWidthChanged(implicitWidth);
+  if (m_componentComplete && m_surface) {
+    m_surface->sendSize(m_size);
+  }
+}
+
+int QuickEmbeddedShellWindow::implicitHeight() const {
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.height();
+  return m_size.height();
+}
+
+void QuickEmbeddedShellWindow::setImplicitHeight(int implicitHeight) {
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitHeight;
+  const QSize newSize{m_size.width(), implicitHeight};
+  if (m_size == newSize) {
+    return;
+  }
+  m_size = newSize;
+  Q_EMIT implicitHeightChanged(implicitHeight);
+  if (m_componentComplete && m_surface) {
+    m_surface->sendSize(m_size);
+  }
 }
 
 int QuickEmbeddedShellWindow::margin() const {

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -23,6 +23,9 @@ public:
 
   QuickEmbeddedShellWindow(QWindow *parent = nullptr);
   ~QuickEmbeddedShellWindow() override;
+  // Changes "size" but using "implicit" API style to be consistent with what QtQuick usually does for "wanted size".
+  Q_PROPERTY(int implicitWidth READ implicitWidth WRITE setImplicitWidth NOTIFY implicitWidthChanged)
+  Q_PROPERTY(int implicitHeight READ implicitHeight WRITE setImplicitHeight NOTIFY implicitHeightChanged)
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor
                  NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
@@ -36,6 +39,10 @@ public:
   void classBegin() override;
   void componentComplete() override;
 
+  int implicitWidth() const;
+  void setImplicitWidth(int implicitWidth);
+  int implicitHeight() const;
+  void setImplicitHeight(int implicitHeight);
   int margin() const;
   void setMargin(int newMargin);
   unsigned int sortIndex() const;
@@ -51,15 +58,19 @@ public slots:
                                        uint32_t sort_index);
 
 signals:
+  void implicitWidthChanged(int implicitWidth);
+  void implicitHeightChanged(int implicitHeight);
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sortIndex);
 
 private:
+  QSize m_size;
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   EmbeddedShellSurface *m_surface = nullptr;
   int m_margin = -1;
   unsigned int m_sortIndex = 0;
+  bool m_componentComplete = false;
 };
 
 #endif // QUICKEMBEDDEDSHELLWINDOW_H


### PR DESCRIPTION
Using the set_size request, a client communicates its "desired size".
This allows to distinguish between the client's requests and the
compositor's configuration. This concept is also employed by layershell
and xdg popup.

The size is mapped to a new implicitWidth and implicitHeight property
on EmbeddedShellWindow to match what other QtQuick items use for
"desired size".

Right now, width and height tries to reflect both the acutal window size
as configured by the compositor *and* the client's desired window size.
For anchored windows, however, we want the window resized by the compositor
in the anchored direction but its other axis determined by the client.

Therefore, there's a race between the compositor forcing the window to
a specific size and the client in turn seting its new desired size based
on e.g. a new screen size after rotation. Who wins is undefined.

With this, for a bottom client, you would want to set anchor to "bottom",
and implicitHeight to the desired height. Setting implicitWidth in this
scenario is ignored (unlike layershell no protocol error is raised)
since the width is enforced by the compositor to span the full width
of the bottom area.

For compatibility with existing clients, the surface's actual width or
height is used as a fallback when no respective implicit width or height
is set.

**embedded-compositor: Add object names for areas**
    
Makes it easier to debug what area a surface is in since
console.log will print the object name.

**embedded-compositor: Compress resize handling**

Tries to eliminate redundant resize calls, particularly since
usually width changes and then height.
