### PR TITLE
Allow updating view properties on the client-side after the fact

### DIFF
--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
@@ -32,7 +32,7 @@ public:
     QString currentView() const;
     void setCurrentView(QString newCurrentView);
 
-    const QList<TaskSwitcherEntry> &views() const;
+    QList<TaskSwitcherEntry> views() const;
 
     QAbstractListModel *viewModel() const;
     void setViewModel(QAbstractListModel *newViewModel);
@@ -41,15 +41,14 @@ signals:
     void openRequested();
     void closeRequested();
     void currentViewChanged(QString CurrentView);
-    void viewsChanged(const QList<TaskSwitcherEntry> &views);
+    void viewsChanged();
 
     void viewModelChanged(QAbstractListModel *viewModel);
 
 private:
-    QString m_currentView;
-    QList<TaskSwitcherEntry> m_views = {};
-    QAbstractListModel *m_viewModel = nullptr;
+    void onViewsInserted(const QModelIndex &parent, int first, int last);
+    void onViewsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
 
-private slots:
-    void publishViews();
+    QString m_currentView;
+    QAbstractListModel *m_viewModel = nullptr;
 };

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -70,7 +70,14 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
   Q_D(EmbeddedShellSurface);
   auto view =
       d->view_create(d->embedded_shell_surface::object(), appId, appLabel, appIcon, label, icon, sort_index);
-  auto ret = new EmbeddedShellSurfaceView(view, this, label);
+  auto ret = new EmbeddedShellSurfaceView(view, this);
+
+  auto *viewPrivate = EmbeddedShellSurfaceViewPrivate::get(ret);
+  viewPrivate->m_appLabel = appLabel;
+  viewPrivate->m_appIcon = appIcon;
+  viewPrivate->m_label = label;
+  viewPrivate->m_icon = icon;
+
   return ret;
 }
 
@@ -95,29 +102,76 @@ void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex) {
 
 EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(
     EmbeddedShellSurfaceView *q, ::surface_view *view,
-    EmbeddedShellSurface *surf, const QString &label)
-    : QObject(surf), QtWayland::surface_view(view), m_label(label), q_ptr(q) {}
+    EmbeddedShellSurface *surf)
+    : QObject(surf), QtWayland::surface_view(view), q_ptr(q) {}
 
 EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate() {
   destroy();
 }
 
+EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedShellSurfaceView *q)
+{
+    return q->d_func();
+}
+
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
-                                                   EmbeddedShellSurface *surf,
-                                                   const QString &label)
-    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf, label)) {}
+                                                   EmbeddedShellSurface *surf)
+    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf)) {}
 
 EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView() {}
 
-const QString &EmbeddedShellSurfaceView::label() const {
+QString EmbeddedShellSurfaceView::appLabel() const {
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_appLabel;
+}
+
+void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel) {
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_appLabel == appLabel)
+    return;
+  d->m_appLabel = appLabel;
+  d->set_app_label(appLabel);
+  Q_EMIT appLabelChanged(appLabel);
+}
+
+QString EmbeddedShellSurfaceView::appIcon() const {
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_appIcon;
+}
+
+void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon) {
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_appIcon == appIcon)
+      return;
+  d->m_appIcon = appIcon;
+  d->set_app_icon(appIcon);
+  Q_EMIT appIconChanged(appIcon);
+}
+
+QString EmbeddedShellSurfaceView::label() const {
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_label;
 }
 
-void EmbeddedShellSurfaceView::setLabel(const QString &newLabel) {
+void EmbeddedShellSurfaceView::setLabel(const QString &label) {
   Q_D(EmbeddedShellSurfaceView);
-  if (d->m_label == newLabel)
+  if (d->m_label == label)
     return;
-  d->m_label = newLabel;
-  emit labelChanged();
+  d->m_label = label;
+  d->set_label(label);
+  Q_EMIT labelChanged(label);
+}
+
+QString EmbeddedShellSurfaceView::icon() const {
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_icon;
+}
+
+void EmbeddedShellSurfaceView::setIcon(const QString &icon) {
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_icon == icon)
+    return;
+  d->m_icon = icon;
+  d->set_icon(icon);
+  Q_EMIT iconChanged(icon);
 }

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -63,16 +63,31 @@ class EmbeddedShellSurfaceView : public QObject {
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
 
 public:
-  EmbeddedShellSurfaceView(struct ::surface_view *view,
-                           EmbeddedShellSurface *surf, const QString &label);
   ~EmbeddedShellSurfaceView() override;
 
-  const QString &label() const;
-  void setLabel(const QString &newLabel);
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+  Q_SIGNAL void appLabelChanged(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+  Q_SIGNAL void appIconChanged(const QString &appIcon);
+
+  QString label() const;
+  void setLabel(const QString &label);
+  Q_SIGNAL void labelChanged(const QString &label);
+
+  QString icon() const;
+  void setIcon(const QString &icon);
+  Q_SIGNAL void iconChanged(const QString &icon);
 
 signals:
   void selected();
-  void labelChanged();
+
+private:
+  friend class EmbeddedShellSurface;
+  EmbeddedShellSurfaceView(struct ::surface_view *view,
+                           EmbeddedShellSurface *surf);
 };
 
 #endif // EMBEDDEDSHELLSURFACE_H

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -39,19 +39,25 @@ class EmbeddedShellSurfaceViewPrivate : public QObject,
                                         public QtWayland::surface_view {
   Q_DECLARE_PUBLIC(EmbeddedShellSurfaceView)
   Q_OBJECT
-  QString m_label;
 
 public:
   EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
                                   ::surface_view *view,
-                                  EmbeddedShellSurface *surf,
-                                  const QString &label);
+                                  EmbeddedShellSurface *surf);
   ~EmbeddedShellSurfaceViewPrivate() override;
+
+  static EmbeddedShellSurfaceViewPrivate *get(EmbeddedShellSurfaceView *q);
+
   void surface_view_selected() override {
     qDebug() << __PRETTY_FUNCTION__;
     Q_Q(EmbeddedShellSurfaceView);
     emit q->selected();
   }
   EmbeddedShellSurfaceView *q_ptr = nullptr;
+
+  QString m_appLabel;
+  QString m_appIcon;
+  QString m_label;
+  QString m_icon;
 };
 #endif // EMBEDDEDSHELLSURFACE_P_H


### PR DESCRIPTION
**embeddedplatform: Add getters and setters for view properties**

Allows to change the view properties (like label) after the fact.
Cache them in the object, then send them out when they change.

While at it, make the construtor private, as only `createView`
is supposed to create them. Then just fill in the members
directly rather than passing them all through the constructor.

**TaskSwitcherDBusInterface: Update view properties live**
Connect to the surface view change signals and signal a change.
There's also no real need to cache the properties.


