### PR TITLE
Allow setting app id, label, icon through environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For convenience of QML applications, we also implement a QML interface to embedd
     }
 ```
 
-For third party Qt applications that can not be adapted to interface with the `embedded-shell` protocol, we provide a set of environment variables to choose a compositor slot, width and sort index:
+For third party Qt applications that can not be adapted to interface with the `embedded-shell` protocol, we provide a set of environment variables to choose a compositor slot, width, sort index, and label/icon:
 
 ```sh
     # possible values: center, top, bottom, left, right
@@ -136,6 +136,10 @@ For third party Qt applications that can not be adapted to interface with the `e
     export EMBEDDED_SHELL_SORT_INDEX=100
     # unsigned integer values
     export EMBEDDED_SHELL_MARGIN=32
+    # string
+    export EMBEDDED_SHELL_APP_LABEL="My App"
+    # string (path)
+    export EMBEDDED_SHELL_APP_ICON="file:/opt/myapp/icons/icon.svg"
     # sample application
     kcalc
 ```

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -48,12 +48,27 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
             auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>();
             auto *view = data.value(QStringLiteral("view")).value<EmbeddedShellSurfaceView *>();
 
+            QString appId = surface->appId();
+            if (view && !view->appId().isEmpty()) {
+                appId = view->appId();
+            }
+
+            QString appLabel = surface->appLabel();
+            if (view && !view->appLabel().isEmpty()) {
+                appLabel = view->appLabel();
+            }
+
+            QString appIcon = surface->appIcon();
+            if (view && !view->appIcon().isEmpty()) {
+                appIcon = view->appIcon();
+            }
+
             entries.append({
                 view ? view->getUuid() : surface->getUuid(),
-                view ? view->appId() : QString(),
-                view ? view->appLabel() : QString(),
-                view ? view->appIcon() : QString(),
-                view ? view->label() : QStringLiteral("surface"),
+                appId,
+                appLabel,
+                appIcon,
+                view ? view->label() : QString(),
                 view ? view->icon() : QString(),
                 uint32_t(surface->getClientPid()),
                 view ? uint32_t(view->sortIndex()) : 0,

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -102,6 +102,27 @@ void EmbeddedShellSurface::setSortIndex(unsigned int sort_index) {
   emit sortIndexChanged(sort_index);
 }
 
+void EmbeddedShellSurface::setAppId(const QString &appId) {
+  if (!m_appId.isEmpty()) {
+    return;
+  }
+  m_appId = appId;
+}
+
+void EmbeddedShellSurface::setAppLabel(const QString &appLabel) {
+  if (m_appLabel != appLabel) {
+    m_appLabel = appLabel;
+    Q_EMIT appLabelChanged(appLabel);
+  }
+}
+
+void EmbeddedShellSurface::setAppIcon(const QString &appIcon) {
+  if (m_appIcon != appIcon) {
+    m_appIcon = appIcon;
+    Q_EMIT appIconChanged(appIcon);
+  }
+}
+
 void EmbeddedShellSurface::sendConfigure(const QSize size) {
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << size;
   send_configure(size.width(), size.height());
@@ -320,6 +341,27 @@ void EmbeddedShellSurface::embedded_shell_surface_set_sort_index(
   qCDebug(shellExt) << __PRETTY_FUNCTION__ << sort_index;
   Q_UNUSED(resource)
   setSortIndex(sort_index);
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_app_id(
+    Resource *resource, const QString &appId) {
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appId;
+    Q_UNUSED(resource)
+    setAppId(appId);
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_app_label(
+    Resource *resource, const QString &appLabel) {
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appLabel;
+    Q_UNUSED(resource)
+    setAppLabel(appLabel);
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_app_icon(
+    Resource *resource, const QString &appIcon) {
+    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appIcon;
+    Q_UNUSED(resource)
+    setAppIcon(appIcon);
 }
 
 unsigned int EmbeddedShellSurfaceView::sortIndex() const { return m_sortIndex; }

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -61,17 +61,26 @@ public:
   EmbeddedShellTypes::Anchor getAnchor() { return m_anchor; }
   int getMargin() { return m_margin; }
   unsigned int sortIndex() { return m_sort_index; }
+  QString appId() const { return m_appId; }
+  QString appLabel() const { return m_appLabel; }
+  QString appIcon() const { return m_appIcon; }
   Q_PROPERTY(QSize size READ getSize NOTIFY sizeChanged)
   Q_PROPERTY(
       EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString appId READ appId CONSTANT)
+  Q_PROPERTY(QString appLabel READ appLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon NOTIFY appIconChanged)
   Q_PROPERTY(QString uuid READ getUuid CONSTANT)
 
   void setSize(const QSize &size);
   void setAnchor(embedded_shell_anchor_border newAnchor);
   void setMargin(int newMargin);
   void setSortIndex(unsigned int sort_index);
+  void setAppId(const QString &appId);
+  void setAppLabel(const QString &appLabel);
+  void setAppIcon(const QString &appIcon);
   Q_INVOKABLE void sendConfigure(const QSize size);
   QString getUuid() const;
   pid_t getClientPid() const;
@@ -81,6 +90,8 @@ signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sort_index);
+  void appIconChanged(const QString &appIcon);
+  void appLabelChanged(const QString &appLabel);
   void createView(EmbeddedShellSurfaceView *view);
 
 private:
@@ -89,6 +100,9 @@ private:
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
+  QString m_appId;
+  QString m_appLabel;
+  QString m_appIcon;
   QUuid m_uuid = QUuid::createUuid();
 
   // embedded_shell_surface interface
@@ -107,6 +121,12 @@ protected:
                                          int32_t margin) override;
   void embedded_shell_surface_set_sort_index(Resource *resource,
                                              uint32_t sort_index) override;
+  void embedded_shell_surface_set_app_id(Resource *resource,
+                                         const QString &appId) override;
+  void embedded_shell_surface_set_app_label(Resource *resource,
+                                            const QString &label) override;
+  void embedded_shell_surface_set_app_icon(Resource *resource,
+                                           const QString &icon) override;
 };
 
 class EmbeddedShellSurfaceView : public QObject,

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -111,6 +111,21 @@ void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex) {
   d->set_sort_index(sortIndex);
 }
 
+void EmbeddedShellSurface::sendAppId(const QString &appId) {
+  Q_D(EmbeddedShellSurface);
+  d->set_app_id(appId);
+}
+
+void EmbeddedShellSurface::sendAppLabel(const QString &appLabel) {
+  Q_D(EmbeddedShellSurface);
+  d->set_app_label(appLabel);
+}
+
+void EmbeddedShellSurface::sendAppIcon(const QString &appIcon) {
+  Q_D(EmbeddedShellSurface);
+  d->set_app_icon(appIcon);
+}
+
 EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(
     EmbeddedShellSurfaceView *q, ::surface_view *view,
     EmbeddedShellSurface *surf)

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -57,6 +57,9 @@ public slots:
   void sendAnchor(EmbeddedShellTypes::Anchor anchor);
   void sendMargin(int margin);
   void sendSortIndex(unsigned int sortIndex);
+  void sendAppId(const QString &appId);
+  void sendAppLabel(const QString &appLabe);
+  void sendAppIcon(const QString &appIcon);
 };
 
 class EmbeddedShellSurfaceView : public QObject {

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -15,6 +15,18 @@
 		<request name="set_margin">
 			<arg name="margin" type="int" />
 		</request>
+		<request name="set_app_id"><!-- TODO should probably be since="3" -->
+			<description summary="Set the application ID of the application"/>
+			<arg name="label" type="string"/>
+		</request>
+		<request name="set_app_label"><!-- TODO should probably be since="3" -->
+			<description summary="Set the user-visible name of the application"/>
+			<arg name="label" type="string"/>
+		</request>
+		<request name="set_app_icon"><!-- TODO should probably be since="3" -->
+			<description summary="Set the icon name of this application"/>
+			<arg name="icon" type="string"/>
+		</request>
 
 		<request name="set_size"><!-- TODO should probably be since="2" -->
 			<description summary="Sets the size of the surface">

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -74,6 +74,19 @@ EmbeddedShellIntegration::createShellSurface(
     return nullptr;
   }
 
+  const QString appId = qEnvironmentVariable("EMBEDDED_SHELL_APP_ID");
+  if (!appId.isEmpty()) {
+    ess->sendAppId(appId);
+  }
+  const QString appLabel = qEnvironmentVariable("EMBEDDED_SHELL_APP_LABEL");
+  if (!appLabel.isEmpty()) {
+    ess->sendAppLabel(appLabel);
+  }
+  const QString appIcon = qEnvironmentVariable("EMBEDDED_SHELL_APP_ICON");
+  if (!appIcon.isEmpty()) {
+    ess->sendAppIcon(appIcon);
+  }
+
   m_windows.insert(window, ess);
   emit EmbeddedPlatform::instance()->shellSurfaceCreated(ess, window->window());
   return ess->shellSurface();


### PR DESCRIPTION
For applications that use EmbeddedShell only through the shell integration, this adds three new environment variables to set the app id, label, icon:

EMBEDDED_SHELL_APP_ID, EMBEDDED_SHELL_APP_LABEL, EMBEDDED_SHELL_APP_ICON.

View properties, if any, take precedence.

The fallback to return "surface" as surface label has been removed. It is the UI's responsibility to display the appropriate app label in this case.