### PR TITLE
shellintegration: Rewrite to be inline with upstream

### DIFF
--- a/embeddedplatform/embeddedshell.h
+++ b/embeddedplatform/embeddedshell.h
@@ -19,18 +19,15 @@ namespace QtWaylandClient {
 class QWaylandWindow;
 }
 
-class EmbeddedShell : QWaylandClientExtension {
-  Q_OBJECT
-  QtWayland::embedded_shell *instance;
-
+class EmbeddedShell {
 public:
-  bool isActive() { return QWaylandClientExtension::isActive(); }
-  EmbeddedShell();
+  explicit EmbeddedShell(QtWayland::embedded_shell *embeddedShell);
   EmbeddedShellSurface *createSurface(QtWaylandClient::QWaylandWindow *window,
                                       EmbeddedShellTypes::Anchor anchor,
                                       uint32_t margin, unsigned int sort_index);
-  const struct wl_interface *extensionInterface() const override;
-  void bind(struct ::wl_registry *registry, int id, int ver) override;
+
+private:
+  QtWayland::embedded_shell *m_embeddedShell;
 };
 
 #endif // EMBEDDEDSHELL_H

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -5,10 +5,17 @@
 #include "embeddedshell.h"
 #include "embeddedshellsurface.h"
 
-bool EmbeddedShellIntegration::isActive() const { return m_shell->isActive(); }
-
 EmbeddedShellIntegration::EmbeddedShellIntegration()
-    : m_shell(new EmbeddedShell()) {}
+  : QtWaylandClient::QWaylandShellIntegrationTemplate<EmbeddedShellIntegration>(/*version*/ 1)
+{
+  connect(this, &QWaylandShellIntegrationTemplate::activeChanged, this, [this] {
+    if (isActive()) {
+      m_shell.reset(new EmbeddedShell(this));
+    } else {
+      m_shell.reset();
+    }
+  });
+}
 
 QtWaylandClient::QWaylandShellSurface *
 EmbeddedShellIntegration::createShellSurface(
@@ -90,16 +97,6 @@ EmbeddedShellIntegration::createShellSurface(
   m_windows.insert(window, ess);
   emit EmbeddedPlatform::instance()->shellSurfaceCreated(ess, window->window());
   return ess->shellSurface();
-}
-
-bool EmbeddedShellIntegration::initialize(
-    QtWaylandClient::QWaylandDisplay *display) {
-#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
-    QWaylandShellIntegration::initialize(display);
-#else
-    Q_UNUSED(display);
-#endif
-  return m_shell->isActive();
 }
 
 void *

--- a/shellintegration/embeddedshellintegration.h
+++ b/shellintegration/embeddedshellintegration.h
@@ -4,8 +4,9 @@
 #define EMBEDDEDSHELLINTEGRATION_H
 
 #include <QScopedPointer>
-#include <QtWaylandClient/private/qwaylandclientextension_p.h>
 #include <QtWaylandClient/private/qwaylandshellintegration_p.h>
+
+#include "qwayland-embedded-shell.h"
 
 class EmbeddedShellSurface;
 class EmbeddedShell;
@@ -16,20 +17,21 @@ Q_WAYLAND_CLIENT_EXPORT
 #else
 Q_WAYLANDCLIENT_EXPORT
 #endif
-        EmbeddedShellIntegration
-    : public QtWaylandClient::QWaylandShellIntegration {
-  QMap<QtWaylandClient::QWaylandWindow *, EmbeddedShellSurface *> m_windows;
-  QScopedPointer<EmbeddedShell> m_shell;
-
+EmbeddedShellIntegration
+  : public QtWaylandClient::QWaylandShellIntegrationTemplate<EmbeddedShellIntegration>
+  , public QtWayland::embedded_shell
+{
 public:
-  bool isActive() const;
   EmbeddedShellIntegration();
   QtWaylandClient::QWaylandShellSurface *
   createShellSurface(QtWaylandClient::QWaylandWindow *window) override;
-  bool initialize(QtWaylandClient::QWaylandDisplay *display) override;
   // QWaylandShellIntegration interface
   void *nativeResourceForWindow(const QByteArray &resource,
                                 QWindow *window) override;
+
+private:
+  QScopedPointer<EmbeddedShell> m_shell;
+  QMap<QtWaylandClient::QWaylandWindow *, EmbeddedShellSurface *> m_windows;
 };
 
 #endif // EMBEDDEDSHELLINTEGRATION_H

--- a/shellintegration/main.cpp
+++ b/shellintegration/main.cpp
@@ -18,15 +18,9 @@ public:
 QtWaylandClient::QWaylandShellIntegration *
 EmbeddedShellIntegrationPlugin::create(const QString &key,
                                        const QStringList &paramList) {
-  auto v = new EmbeddedShellIntegration();
-  // there is a queued connection in QWaylandClientExtension
-  // that will not fire unless we process the event loop
-  while (!v->isActive()) {
-    QCoreApplication::processEvents();
-  }
   Q_UNUSED(key)
   Q_UNUSED(paramList)
-  return v;
+  return new EmbeddedShellIntegration();
 }
 
 #include "main.moc"


### PR DESCRIPTION
This reimplements EmbeddedShellIntegration to be in line with how upstream QWaylandXdgShellIntegration works.

EmbeddedShellIntegration now uses QWaylandShellIntegrationTemplate and inherits embedded_shell, too. This ensures proper initialization of the Wayland side.

The underlying EmbeddedShell is created once the extension has been initialized.

This makes it work under Qt 6 and removes the need for the processEvents loop in EmbeddedShellIntegrationPlugin which in Qt 6 causes the extension to never be initialized, entering an infinite loop and clients not starting up properly.