### PR TITLE
Add connect for viewsChanged signal

### DIFF
--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -120,6 +120,10 @@ void TaskSwitcherDBusInterface::setViewModel(QAbstractListModel *newViewModel)
                 &TaskSwitcherDBusInterface::onViewsInserted);
         connect(m_viewModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
                 &TaskSwitcherDBusInterface::onViewsAboutToBeRemoved);
+        connect(m_viewModel, &QAbstractItemModel::rowsInserted, this,
+                &TaskSwitcherDBusInterface::viewsChanged);
+        connect(m_viewModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
+                &TaskSwitcherDBusInterface::viewsChanged);
     }
 
     Q_EMIT viewModelChanged(m_viewModel);


### PR DESCRIPTION
Mit den zusätzlichen connect, wird das Signal viewsChanged beim Registrieren und Entfernen einer View aufgerufen.