### PR TITLE
created QML interface for EmbeddedShellSurfaceView and implemented su…

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
+      - name: Update Package Index
+        run: sudo apt update
+
       - name: Install dependencies (linux)
         run: sudo apt install ninja-build wayland-protocols wayland-scanner++ libwayland-dev
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ For convenience of QML applications, we also implement a QML interface to embedd
 ```qml
     import EmbeddedShell 1.0
     Window {
-        id: window
+        id: myWindow
         visible: true
-        title: qsTr("Hello from CenterCLient")
+        title: qsTr("Hello from CenterClient")
         anchor: Window.Anchor.Center
         color: "darkgray"
         width: 200
@@ -131,9 +131,40 @@ For convenience of QML applications, we also implement a QML interface to embedd
         MouseArea {
             anchors.fill: parent
             onClicked: {
-                var view = window.createView("view name", 42);
-                view.selected.connect(function(){ console.log("view "+ view.label +" was selected"); })
+                var appId = "MyApp"
+                var appLabel = "My App"
+                var label = "My View"
+                var sortIndex = 0
+                var view = myWindow.createView(appId, appLabel, label, sortIndex);
+                view.selected.connect(function(){ console.log("view", view.label, "was selected"); })
             }
+        }
+    }
+```
+
+A declarative QML interface to embedded_shell_surface_view is also available (see [.h](/quickembeddedshellwindow/quickembeddedshellview.h), [.cpp](quickembeddedshellwindow/quickembeddedshellview.cpp))
+
+```qml
+    import EmbeddedShell 1.0
+    Window {
+        id: myWindow
+        visible: true
+        title: qsTr("Hello from CenterClient")
+        anchor: Window.Anchor.Center
+        color: "darkgray"
+        width: 200
+        height:200
+        
+        View {
+            id: myView
+            window: myWindow
+            appId: "MyApp"
+            appLabel: "My App"
+            label: "My View"
+            sortIndex: 0
+            
+            Text { text: myView.label }
+        }
     }
 ```
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ There is an alternative method to detect shell surface creation which is waiting
 
 ```
 
-For convenience of QML applications, we also implement a QML interface to embedded_shell_surface, which is implemented in the sub project "quickembeddedshellwindow" (see [.h](/quickembeddedshellwindow/quickembeddedshellwindow.h), [.cpp](quickembeddedshellwindow/quickembeddedshellwindow.cpp))
+For convenience of QML applications, we also implement a QML interface to embedded_shell_surface, which is implemented in the sub project "quickembeddedshellwindow" (see [.h](/quickembeddedshellwindow/quickembeddedshellwindow.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellwindow.cpp))
 
 ```qml
     import EmbeddedShell 1.0
@@ -142,7 +142,7 @@ For convenience of QML applications, we also implement a QML interface to embedd
     }
 ```
 
-A declarative QML interface to embedded_shell_surface_view is also available (see [.h](/quickembeddedshellwindow/quickembeddedshellview.h), [.cpp](quickembeddedshellwindow/quickembeddedshellview.cpp))
+A declarative QML interface to embedded_shell_surface_view is also available (see [.h](/quickembeddedshellwindow/quickembeddedshellview.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellview.cpp))
 
 ```qml
     import EmbeddedShell 1.0
@@ -157,7 +157,7 @@ A declarative QML interface to embedded_shell_surface_view is also available (se
         
         View {
             id: myView
-            window: myWindow
+            embeddedShellWindow: myWindow
             appId: "MyApp"
             appLabel: "My App"
             label: "My View"

--- a/dev-tools/testclients/quickcenterclient/main.qml
+++ b/dev-tools/testclients/quickcenterclient/main.qml
@@ -6,7 +6,7 @@ import EmbeddedShell 1.0 as EmbeddedShell
 EmbeddedShell.Window {
     id: window
     visible: true
-    title: qsTr("Hello from CenterCLient")
+    title: qsTr("Hello from CenterClient")
     anchor: EmbeddedShell.Window.Anchor.Center
     color: "darkgray"
     width: 200

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -225,10 +225,6 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
 {
 }
 
-EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView()
-{
-}
-
 QString EmbeddedShellSurfaceView::appId() const
 {
     return m_appId;
@@ -390,5 +386,6 @@ void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
 void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource) {
     Q_UNUSED(resource)
     emit aboutToBeDestroyed();
+    QtWaylandServer::surface_view::surface_view_destroy(resource);
     deleteLater();
 }

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -225,6 +225,10 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
 {
 }
 
+EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView()
+{
+}
+
 QString EmbeddedShellSurfaceView::appId() const
 {
     return m_appId;
@@ -381,4 +385,10 @@ void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
                                                            uint32_t sort_index) {
   Q_UNUSED(resource)
   setSortIndex(sort_index);
+}
+
+void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource) {
+    Q_UNUSED(resource)
+    emit aboutToBeDestroyed();
+    deleteLater();
 }

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -28,7 +28,8 @@ Q_ENUM_NS(Anchor)
 
 class EmbeddedShellExtension
     : public QWaylandShellTemplate<EmbeddedShellExtension>,
-      public QtWaylandServer::embedded_shell {
+      public QtWaylandServer::embedded_shell
+{
   Q_OBJECT
 public:
   explicit EmbeddedShellExtension(QWaylandCompositor *compositor);
@@ -45,7 +46,8 @@ signals:
 
 class EmbeddedShellSurface
     : public QWaylandShellSurfaceTemplate<EmbeddedShellSurface>,
-      public QtWaylandServer::embedded_shell_surface {
+      public QtWaylandServer::embedded_shell_surface
+{
   Q_OBJECT
 public:
   EmbeddedShellSurface(EmbeddedShellExtension *ext, QWaylandSurface *surface,
@@ -145,6 +147,7 @@ public:
   EmbeddedShellSurfaceView(const QString &appId, const QString &appLabel, const QString &appIcon,
                            const QString &label, const QString &icon, uint32_t sort_index,
                            wl_client *client, int id, int version);
+  ~EmbeddedShellSurfaceView();
 
   QString appId() const;
   void setAppId(const QString &appId);
@@ -173,8 +176,10 @@ public:
 
 public slots:
   void select() { surface_view::send_selected(); }
+
 signals:
   void sortIndexChanged(unsigned int index);
+  void aboutToBeDestroyed();
 
 protected:
   void surface_view_set_app_label(Resource *resource, const QString &label) override;
@@ -183,6 +188,7 @@ protected:
   void surface_view_set_icon(Resource *resource, const QString &icon) override;
   void surface_view_set_sort_index(Resource *resource,
                                    uint32_t sort_index) override;
+  void surface_view_destroy(Resource *resource) override;
 
 private:
   QUuid m_uuid = QUuid::createUuid();
@@ -194,7 +200,8 @@ private:
   uint32_t m_sortIndex = 0;
 };
 
-class QuickEmbeddedShellIntegration : public QWaylandQuickShellIntegration {
+class QuickEmbeddedShellIntegration : public QWaylandQuickShellIntegration
+{
   Q_OBJECT
 public:
   QuickEmbeddedShellIntegration(QWaylandQuickShellSurfaceItem *item);

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -147,7 +147,6 @@ public:
   EmbeddedShellSurfaceView(const QString &appId, const QString &appLabel, const QString &appIcon,
                            const QString &label, const QString &icon, uint32_t sort_index,
                            wl_client *client, int id, int version);
-  ~EmbeddedShellSurfaceView();
 
   QString appId() const;
   void setAppId(const QString &appId);

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -83,7 +83,7 @@ WaylandCompositor {
                 focus: true
             }
 
-            Rectangle {
+            Item {
                 id: centerArea
                 objectName: "centerArea"
                 anchors.top: !rootTransformItem.fullScreen ? topArea.bottom : rootTransformItem.top
@@ -95,10 +95,6 @@ WaylandCompositor {
                     y: keyboardLoader.contentYTranslate
                 }
 
-                border {
-                    width: 1
-                    color:"red"
-                }
                 property Item surfaceItem
                 onSurfaceItemChanged: {
                     if(surfaceItem == null) {
@@ -112,11 +108,11 @@ WaylandCompositor {
                         taskSwitcherInterface.currentView = surfaceItem.uuid
                     }
                 }
+
                 property ShellSurface surface
-                function selectSurface(shellSurface, view)
-                {
-                    for(var i =0; i < children.length; i++)
-                    {
+
+                function selectSurface(shellSurface, view) {
+                    for (var i = 0; i < children.length; i++) {
                         var window = children[i];
                         if(window.shellSurface === shellSurface) {
                             window.currentView = view;
@@ -127,6 +123,7 @@ WaylandCompositor {
                     }
                 }
             }
+
             Item {
                 id: leftArea
                 objectName: "leftArea"
@@ -137,6 +134,7 @@ WaylandCompositor {
                 property Item surfaceItem
                 visible: !rootTransformItem.fullScreen
             }
+
             Item {
                 id: rightArea
                 objectName: "rightArea"
@@ -147,6 +145,7 @@ WaylandCompositor {
                 property Item surfaceItem
                 visible: !rootTransformItem.fullScreen
             }
+
             Item {
                 id: topArea
                 objectName: "topArea"
@@ -157,6 +156,7 @@ WaylandCompositor {
                 property Item surfaceItem
                 visible: !rootTransformItem.fullScreen
             }
+
             Item {
                 id: bottomArea
                 objectName: "bottomArea"
@@ -235,10 +235,8 @@ WaylandCompositor {
         id: centerApplicationViewModel
         property var surfaces: ({});
 
-        function addSurface(shellSurface, shellSurfaceItem)
-        {
-            if(surfaces.hasOwnProperty(shellSurface))
-            {
+        function addSurface(shellSurface, shellSurfaceItem) {
+            if(surfaces.hasOwnProperty(shellSurface)) {
                 console.debug("application model: duplicate key! "+shellSurface.uuid);
                 return;
             }
@@ -256,31 +254,24 @@ WaylandCompositor {
             });
         }
 
-        function removeSurface(shellSurface)
-        {
-            for(var i = count - 1; i >= 0; i--)
-            {
-                if(get(i).data.surface === shellSurface)
-                {
+        function removeSurface(shellSurface) {
+            for (var i = count - 1; i >= 0; i--) {
+                if(get(i).data.surface === shellSurface) {
                     remove(i);
                 }
             }
             delete surfaces[shellSurface]
         }
 
-        function createView(shellSurface, view)
-        {
+        function createView(shellSurface, view) {
             var entry = surfaces[shellSurface];
             console.log("compositor: create view! "+ view +" have entry "+entry);
-            if(entry.views.length === 0)
-            {
+            if(entry.views.length === 0) {
                 console.log("setting first view!");
                 entry.views.push(view);
                 append({data: {view: view, surface: shellSurface}});
-                for(var i = 0; i<count; i++)
-                {
-                    if(get(i).data.surface === shellSurface)
-                    {
+                for (var i = 0; i < count; i++) {
+                    if(get(i).data.surface === shellSurface) {
                         remove(i);
                         break;
                     }
@@ -291,8 +282,8 @@ WaylandCompositor {
             }
 
             view.aboutToBeDestroyed.connect(function() {
-                for (var i = 0; i< count; i++) {
-                    var data = get(i).data
+                for (var i = 0; i < count; i++) {
+                    var data = get(i).data;
                     if (data.view === view) {
                         var surface = data.surface;
                         remove(i);
@@ -303,9 +294,8 @@ WaylandCompositor {
                         }
 
                         var entry = surfaces[shellSurface];
-                        var index = entry.views.indexOf(view)
-                        if (index >= 0)
-                        {
+                        var index = entry.views.indexOf(view);
+                        if (index >= 0) {
                             entry.views.splice(index, 1);
                         }
 
@@ -317,13 +307,10 @@ WaylandCompositor {
             append({data: {view: view, surface: shellSurface}});
         }
 
-        function findByUuid(uuid)
-        {
-            for(var i = 0; i<count; i++)
-            {
+        function findByUuid(uuid) {
+            for (var i = 0; i < count; i++) {
                 var entry = get(i).data;
-                if (entry.surface.uuid === uuid || entry.view !== null && entry.view.uuid === uuid)
-                {
+                if (entry.surface.uuid === uuid || entry.view !== null && entry.view.uuid === uuid) {
                     return entry
                 }
             }
@@ -332,6 +319,7 @@ WaylandCompositor {
 
     Component {
         id: chromeComponent
+
         ShellSurfaceItem {
             id: shellSurfaceItem
 
@@ -417,7 +405,6 @@ WaylandCompositor {
             }
         }
     }
-
 
     EmbeddedShell {
         onSurfaceAdded: chromeComponent.createObject(limboArea, { "shellSurface": surface } );

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -128,7 +128,7 @@ WaylandCompositor {
                 }
             }
             Item {
-                id:leftArea
+                id: leftArea
                 objectName: "leftArea"
                 width: surfaceItem ? surfaceItem.margin:window.initialSize
                 anchors.bottom: bottomArea.top
@@ -138,7 +138,7 @@ WaylandCompositor {
                 visible: !rootTransformItem.fullScreen
             }
             Item {
-                id:rightArea
+                id: rightArea
                 objectName: "rightArea"
                 width: surfaceItem ? surfaceItem.margin :window.initialSize
                 anchors.bottom:bottomArea.top
@@ -169,7 +169,7 @@ WaylandCompositor {
             }
 
             Loader {
-                id:taskSwitcherLoader
+                id: taskSwitcherLoader
                 anchors.fill:parent
                 source: configuration.taskSwitcherUrl
                 active: true
@@ -290,6 +290,30 @@ WaylandCompositor {
                 return;
             }
 
+            view.aboutToBeDestroyed.connect(function() {
+                for (var i = 0; i< count; i++) {
+                    var data = get(i).data
+                    if (data.view === view) {
+                        var surface = data.surface;
+                        remove(i);
+
+                        // Fall back to uuid of surface
+                        if (taskSwitcherInterface.currentView === view.uuid) {
+                            taskSwitcherInterface.currentView = data.surface.uuid;
+                        }
+
+                        var entry = surfaces[shellSurface];
+                        var index = entry.views.indexOf(view)
+                        if (index >= 0)
+                        {
+                            entry.views.splice(index, 1);
+                        }
+
+                        break;
+                    }
+                }
+            });
+
             append({data: {view: view, surface: shellSurface}});
         }
 
@@ -304,7 +328,6 @@ WaylandCompositor {
                 }
             }
         }
-
     }
 
     Component {
@@ -399,6 +422,7 @@ WaylandCompositor {
     EmbeddedShell {
         onSurfaceAdded: chromeComponent.createObject(limboArea, { "shellSurface": surface } );
     }
+
     TaskSwitcherInterface {
         id: taskSwitcherInterface
         onOpenRequested: taskSwitcherLoader.item.open();
@@ -409,6 +433,7 @@ WaylandCompositor {
             centerArea.selectSurface(entry.surface, entry.view);
         }
     }
+
     GlobalOverlayInterface {
         onShowRequested: (message) => {
             globalOverlayLoader.item.show(message);

--- a/embedded-compositor/sortfilterproxymodel.cpp
+++ b/embedded-compositor/sortfilterproxymodel.cpp
@@ -2,7 +2,8 @@
 
 #include "sortfilterproxymodel.h"
 
-SortFilterProxyModel::SortFilterProxyModel() {
+SortFilterProxyModel::SortFilterProxyModel()
+{
   setDynamicSortFilter(true);
   QSortFilterProxyModel::sort(0);
   connect(this, &QSortFilterProxyModel::rowsInserted, this,
@@ -11,7 +12,8 @@ SortFilterProxyModel::SortFilterProxyModel() {
           &SortFilterProxyModel::countChanged);
 }
 
-void SortFilterProxyModel::setSourceModel(QAbstractItemModel *newSourceModel) {
+void SortFilterProxyModel::setSourceModel(QAbstractItemModel *newSourceModel)
+{
   if (sourceModel() == newSourceModel)
     return;
   QSortFilterProxyModel::setSourceModel(newSourceModel);
@@ -32,16 +34,19 @@ void SortFilterProxyModel::initRoles() {
   resetInternalData();
 }
 
-QHash<int, QByteArray> SortFilterProxyModel::roleNames() const {
+QHash<int, QByteArray> SortFilterProxyModel::roleNames() const
+{
   return sourceModel() != nullptr ? sourceModel()->roleNames()
                                   : QHash<int, QByteArray>();
 }
 
-const QString &SortFilterProxyModel::sortFunction() const {
+const QString &SortFilterProxyModel::sortFunction() const
+{
   return m_sortFunction;
 }
 
-void SortFilterProxyModel::setSortFunction(const QString &newSortFunction) {
+void SortFilterProxyModel::setSortFunction(const QString &newSortFunction)
+{
   if (m_sortFunction == newSortFunction)
     return;
   m_sortFunction = newSortFunction;
@@ -49,11 +54,13 @@ void SortFilterProxyModel::setSortFunction(const QString &newSortFunction) {
   emit sortFunctionChanged(m_sortFunction);
 }
 
-const QString &SortFilterProxyModel::acceptFunction() const {
+const QString &SortFilterProxyModel::acceptFunction() const
+{
   return m_acceptFunction;
 }
 
-void SortFilterProxyModel::setAcceptFunction(const QString &newAcceptFunction) {
+void SortFilterProxyModel::setAcceptFunction(const QString &newAcceptFunction)
+{
   if (m_acceptFunction == newAcceptFunction)
     return;
   m_acceptFunction = newAcceptFunction;
@@ -64,7 +71,8 @@ void SortFilterProxyModel::setAcceptFunction(const QString &newAcceptFunction) {
 int SortFilterProxyModel::count() const { return rowCount(); }
 
 bool SortFilterProxyModel::lessThan(const QModelIndex &left,
-                                    const QModelIndex &right) const {
+                                    const QModelIndex &right) const
+{
   QVariant leftData = sourceModel()->data(left);
   QVariant rightData = sourceModel()->data(right);
   QVariant returnedValue;
@@ -77,20 +85,20 @@ bool SortFilterProxyModel::lessThan(const QModelIndex &left,
 }
 
 bool SortFilterProxyModel::filterAcceptsRow(
-    int sourceRow, const QModelIndex &sourceParent) const {
-
+    int sourceRow, const QModelIndex &sourceParent) const
+{
   if (m_acceptFunction.isEmpty()) {
     return true;
   }
 
   QModelIndex index0 = sourceModel()->index(sourceRow, 0, sourceParent);
-  QObject *item = sourceModel()->data(index0).value<QObject *>();
+  QVariant data = sourceModel()->data(index0);
   bool accepts = false;
   QVariant returnedValue;
   QMetaObject::invokeMethod(const_cast<SortFilterProxyModel *>(this),
                             m_acceptFunction.toUtf8().constData(),
                             Q_RETURN_ARG(QVariant, returnedValue),
-                            Q_ARG(QVariant, QVariant::fromValue(item)));
+                            Q_ARG(QVariant, data));
   accepts = returnedValue.toBool();
   return accepts;
 }

--- a/embedded-compositor/sortfilterproxymodel.h
+++ b/embedded-compositor/sortfilterproxymodel.h
@@ -5,7 +5,8 @@
 
 #include <QSortFilterProxyModel>
 
-class SortFilterProxyModel : public QSortFilterProxyModel {
+class SortFilterProxyModel : public QSortFilterProxyModel
+{
   Q_OBJECT
   Q_PROPERTY(QAbstractItemModel *sourceModel READ sourceModel WRITE
                  setSourceModel NOTIFY sourceModelChanged)
@@ -15,6 +16,7 @@ class SortFilterProxyModel : public QSortFilterProxyModel {
   Q_PROPERTY(QString acceptFunction READ acceptFunction WRITE setAcceptFunction
                  NOTIFY acceptFunctionChanged)
   Q_PROPERTY(int count READ count NOTIFY countChanged)
+
 public:
   SortFilterProxyModel();
   void setSourceModel(QAbstractItemModel *newSourceModel) override;
@@ -30,6 +32,7 @@ public:
     return QModelIndex();
   }
   QHash<int, QByteArray> roleNames() const override;
+
 signals:
   void sourceModelChanged(QAbstractItemModel *sourceModel);
   void sortFunctionChanged(const QString &sortFunction);

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -21,10 +21,6 @@ EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shel
 {
 }
 
-EmbeddedShellSurface::~EmbeddedShellSurface()
-{
-}
-
 EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
                                                          QtWaylandClient::QWaylandWindow *window,
                                                          const QSize &size,
@@ -210,10 +206,6 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
 {
 }
 
-EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView()
-{
-}
-
 QString EmbeddedShellSurfaceView::appLabel() const
 {
   Q_D(const EmbeddedShellSurfaceView);
@@ -278,12 +270,13 @@ void EmbeddedShellSurfaceView::setIcon(const QString &icon)
   Q_EMIT iconChanged(icon);
 }
 
-int EmbeddedShellSurfaceView::sortIndex() const
+unsigned int EmbeddedShellSurfaceView::sortIndex() const
 {
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_sortIndex;
 }
-void EmbeddedShellSurfaceView::setSortIndex(int sortIndex)
+
+void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
 {
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_sortIndex == sortIndex)

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -6,46 +6,70 @@
 #include <qpa/qplatformwindow.h>
 #include <qpa/qwindowsysteminterface.h>
 
-EmbeddedShellSurface::EmbeddedShellSurface(
-    struct ::embedded_shell_surface *shell_surface,
-    QtWaylandClient::QWaylandWindow *window, const QSize &size, EmbeddedShellTypes::Anchor anchor,
-    uint32_t margin, uint32_t sort_index)
-    : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface, window, size, anchor,
-                                            margin, sort_index)) {}
+EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
+                                           QtWaylandClient::QWaylandWindow *window,
+                                           const QSize &size,
+                                           EmbeddedShellTypes::Anchor anchor,
+                                           uint32_t margin,
+                                           uint32_t sort_index)
+    : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface,
+                                            window,
+                                            size,
+                                            anchor,
+                                            margin,
+                                            sort_index))
+{
+}
 
-EmbeddedShellSurface::~EmbeddedShellSurface() {}
+EmbeddedShellSurface::~EmbeddedShellSurface()
+{
+}
 
-EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(
-    struct ::embedded_shell_surface *shell_surface,
-    QtWaylandClient::QWaylandWindow *window, const QSize &size, EmbeddedShellTypes::Anchor anchor,
-    uint32_t margin, uint32_t sort_index)
-    : QWaylandShellSurface(window), QtWayland::embedded_shell_surface(
-                                        shell_surface),
-      m_size(size), m_anchor(anchor), m_margin(margin), m_sort_index(sort_index) {}
+EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
+                                                         QtWaylandClient::QWaylandWindow *window,
+                                                         const QSize &size,
+                                                         EmbeddedShellTypes::Anchor anchor,
+                                                         uint32_t margin,
+                                                         uint32_t sort_index)
+    : QWaylandShellSurface(window)
+    , QtWayland::embedded_shell_surface(shell_surface)
+    , m_size(size)
+    , m_anchor(anchor)
+    , m_margin(margin)
+    , m_sort_index(sort_index)
+{
+}
 
-EmbeddedShellSurfacePrivate::~EmbeddedShellSurfacePrivate() {}
+EmbeddedShellSurfacePrivate::~EmbeddedShellSurfacePrivate()
+{
+}
 
-QSize EmbeddedShellSurface::getSize() const {
+QSize EmbeddedShellSurface::getSize() const
+{
   Q_D(const EmbeddedShellSurface);
   return d->m_size;
 }
 
-EmbeddedShellTypes::Anchor EmbeddedShellSurface::getAnchor() const {
+EmbeddedShellTypes::Anchor EmbeddedShellSurface::getAnchor() const
+{
   Q_D(const EmbeddedShellSurface);
   return d->m_anchor;
 }
 
-unsigned int EmbeddedShellSurface::getSortIndex() const {
+unsigned int EmbeddedShellSurface::getSortIndex() const
+{
   Q_D(const EmbeddedShellSurface);
   return d->m_sort_index;
 }
 
-void EmbeddedShellSurfacePrivate::applyConfigure() {
+void EmbeddedShellSurfacePrivate::applyConfigure()
+{
   window()->resizeFromApplyConfigure(m_pendingSize);
 }
 
-void EmbeddedShellSurfacePrivate::embedded_shell_surface_configure(
-    int32_t width, int32_t height) {
+void EmbeddedShellSurfacePrivate::embedded_shell_surface_configure(int32_t width,
+                                                                   int32_t height)
+{
   m_pendingSize = {width, height};
   window()->applyConfigureWhenPossible();
 }
@@ -54,7 +78,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
                                                            uint32_t sort_index)
 {
-    return createView(QString(), QString(), QString(), label, icon, sort_index);
+  return createView(QString(), QString(), QString(), label, icon, sort_index);
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
@@ -62,7 +86,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            const QString &icon,
                                                            uint32_t sort_index)
 {
-    return createView(appId, QString(), QString(), label, icon, sort_index);
+  return createView(appId, QString(), QString(), label, icon, sort_index);
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
@@ -73,85 +97,131 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            uint32_t sort_index)
 {
   Q_D(EmbeddedShellSurface);
-  auto view =
-      d->view_create(d->embedded_shell_surface::object(), appId, appLabel, appIcon, label, icon, sort_index);
-  auto ret = new EmbeddedShellSurfaceView(view, this);
+  auto waylandView = d->view_create(d->embedded_shell_surface::object(),
+                             appId,
+                             appLabel,
+                             appIcon,
+                             label,
+                             icon,
+                             sort_index);
 
-  auto *viewPrivate = EmbeddedShellSurfaceViewPrivate::get(ret);
+  auto view = new EmbeddedShellSurfaceView(waylandView, this);
+
+  auto *viewPrivate = EmbeddedShellSurfaceViewPrivate::get(view);
+
+  viewPrivate->m_appId = appId;
   viewPrivate->m_appLabel = appLabel;
   viewPrivate->m_appIcon = appIcon;
   viewPrivate->m_label = label;
   viewPrivate->m_icon = icon;
+  viewPrivate->m_sortIndex = sort_index;
 
-  return ret;
+  connect(view, &EmbeddedShellSurfaceView::selected, d, [view, d]() {
+    if (d->m_selectedView != view) {
+      if (d->m_selectedView) {
+        d->m_selectedView->deselected();
+      }
+
+      d->m_selectedView = view;
+    }
+  });
+
+  return view;
 }
 
-QtWaylandClient::QWaylandShellSurface *EmbeddedShellSurface::shellSurface() {
+QtWaylandClient::QWaylandShellSurface *EmbeddedShellSurface::shellSurface()
+{
   return d_ptr.data();
 }
 
-void EmbeddedShellSurface::sendSize(const QSize &size) {
+void EmbeddedShellSurface::sendSize(const QSize &size)
+{
   Q_D(EmbeddedShellSurface);
   // Check version here if it were versioned.
   d->set_size(size.width(), size.height());
 }
 
-void EmbeddedShellSurface::sendAnchor(EmbeddedShellTypes::Anchor anchor) {
+void EmbeddedShellSurface::sendAnchor(EmbeddedShellTypes::Anchor anchor)
+{
   Q_D(EmbeddedShellSurface);
   d->set_anchor(static_cast<embedded_shell_anchor_border>(anchor));
 }
 
-void EmbeddedShellSurface::sendMargin(int margin) {
+void EmbeddedShellSurface::sendMargin(int margin)
+{
   Q_D(EmbeddedShellSurface);
   d->set_margin(margin);
 }
 
-void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex) {
+void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex)
+{
   Q_D(EmbeddedShellSurface);
   d->set_sort_index(sortIndex);
 }
 
-void EmbeddedShellSurface::sendAppId(const QString &appId) {
+void EmbeddedShellSurface::sendAppId(const QString &appId)
+{
   Q_D(EmbeddedShellSurface);
   d->set_app_id(appId);
 }
 
-void EmbeddedShellSurface::sendAppLabel(const QString &appLabel) {
+void EmbeddedShellSurface::sendAppLabel(const QString &appLabel)
+{
   Q_D(EmbeddedShellSurface);
   d->set_app_label(appLabel);
 }
 
-void EmbeddedShellSurface::sendAppIcon(const QString &appIcon) {
+void EmbeddedShellSurface::sendAppIcon(const QString &appIcon)
+{
   Q_D(EmbeddedShellSurface);
   d->set_app_icon(appIcon);
 }
 
-EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(
-    EmbeddedShellSurfaceView *q, ::surface_view *view,
-    EmbeddedShellSurface *surf)
-    : QObject(surf), QtWayland::surface_view(view), q_ptr(q) {}
+EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
+                                                                 ::surface_view *view,
+                                                                 EmbeddedShellSurface *surf)
+    : QObject(surf)
+    , QtWayland::surface_view(view)
+    , q_ptr(q)
+    , m_sortIndex(0)
+{
+}
 
-EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate() {
+EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate()
+{
   destroy();
 }
 
 EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedShellSurfaceView *q)
 {
-    return q->d_func();
+  return q->d_func();
+}
+
+void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
+{
+  qDebug() << __PRETTY_FUNCTION__;
+  Q_Q(EmbeddedShellSurfaceView);
+  emit q->selected();
 }
 
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
                                                    EmbeddedShellSurface *surf)
-    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf)) {}
+    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf))
+{
+}
 
-EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView() {}
+EmbeddedShellSurfaceView::~EmbeddedShellSurfaceView()
+{
+}
 
-QString EmbeddedShellSurfaceView::appLabel() const {
+QString EmbeddedShellSurfaceView::appLabel() const
+{
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_appLabel;
 }
 
-void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel) {
+void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
+{
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_appLabel == appLabel)
     return;
@@ -160,26 +230,30 @@ void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel) {
   Q_EMIT appLabelChanged(appLabel);
 }
 
-QString EmbeddedShellSurfaceView::appIcon() const {
+QString EmbeddedShellSurfaceView::appIcon() const
+{
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_appIcon;
 }
 
-void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon) {
+void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
+{
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_appIcon == appIcon)
-      return;
+    return;
   d->m_appIcon = appIcon;
   d->set_app_icon(appIcon);
   Q_EMIT appIconChanged(appIcon);
 }
 
-QString EmbeddedShellSurfaceView::label() const {
+QString EmbeddedShellSurfaceView::label() const
+{
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_label;
 }
 
-void EmbeddedShellSurfaceView::setLabel(const QString &label) {
+void EmbeddedShellSurfaceView::setLabel(const QString &label)
+{
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_label == label)
     return;
@@ -188,16 +262,33 @@ void EmbeddedShellSurfaceView::setLabel(const QString &label) {
   Q_EMIT labelChanged(label);
 }
 
-QString EmbeddedShellSurfaceView::icon() const {
+QString EmbeddedShellSurfaceView::icon() const
+{
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_icon;
 }
 
-void EmbeddedShellSurfaceView::setIcon(const QString &icon) {
+void EmbeddedShellSurfaceView::setIcon(const QString &icon)
+{
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_icon == icon)
     return;
   d->m_icon = icon;
   d->set_icon(icon);
   Q_EMIT iconChanged(icon);
+}
+
+int EmbeddedShellSurfaceView::sortIndex() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_sortIndex;
+}
+void EmbeddedShellSurfaceView::setSortIndex(int sortIndex)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_sortIndex == sortIndex)
+    return;
+  d->m_sortIndex = sortIndex;
+  d->set_sort_index(sortIndex);
+  Q_EMIT sortIndexChanged(sortIndex);
 }

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -30,7 +30,6 @@ public:
                        const QSize &size,
                        EmbeddedShellTypes::Anchor anchor, uint32_t margin,
                        uint32_t sort_index);
-  ~EmbeddedShellSurface() override;
 
   QSize getSize() const;
   EmbeddedShellTypes::Anchor getAnchor() const;
@@ -69,8 +68,6 @@ class EmbeddedShellSurfaceView : public QObject {
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
 
 public:
-  ~EmbeddedShellSurfaceView() override;
-
   QString appLabel() const;
   void setAppLabel(const QString &appLabel);
   Q_SIGNAL void appLabelChanged(const QString &appLabel);
@@ -87,9 +84,9 @@ public:
   void setIcon(const QString &icon);
   Q_SIGNAL void iconChanged(const QString &icon);
 
-  int sortIndex() const;
-  void setSortIndex(int sortIndex);
-  Q_SIGNAL void sortIndexChanged(int sortIndex);
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int sortIndex);
+  Q_SIGNAL void sortIndexChanged(unsigned int sortIndex);
 
 signals:
   void selected();

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -87,8 +87,13 @@ public:
   void setIcon(const QString &icon);
   Q_SIGNAL void iconChanged(const QString &icon);
 
+  int sortIndex() const;
+  void setSortIndex(int sortIndex);
+  Q_SIGNAL void sortIndexChanged(int sortIndex);
+
 signals:
   void selected();
+  void deselected();
 
 private:
   friend class EmbeddedShellSurface;

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -6,6 +6,7 @@
 #include "embeddedshellsurface.h"
 #include "qwayland-embedded-shell.h"
 #include <QDebug>
+#include <QPointer>
 #include <QtWaylandClient/private/qwaylandshellsurface_p.h>
 
 class EmbeddedShellSurfacePrivate
@@ -32,6 +33,7 @@ private:
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
   QSize m_pendingSize = {0, 0};
+  QPointer<EmbeddedShellSurfaceView> m_selectedView;
   EmbeddedShellSurface *q_ptr = nullptr;
 
 protected:
@@ -47,20 +49,20 @@ public:
   EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
                                   ::surface_view *view,
                                   EmbeddedShellSurface *surf);
+
   ~EmbeddedShellSurfaceViewPrivate() override;
 
   static EmbeddedShellSurfaceViewPrivate *get(EmbeddedShellSurfaceView *q);
 
-  void surface_view_selected() override {
-    qDebug() << __PRETTY_FUNCTION__;
-    Q_Q(EmbeddedShellSurfaceView);
-    emit q->selected();
-  }
+  void surface_view_selected() override;
+
   EmbeddedShellSurfaceView *q_ptr = nullptr;
 
+  QString m_appId;
   QString m_appLabel;
   QString m_appIcon;
   QString m_label;
   QString m_icon;
+  int m_sortIndex;
 };
 #endif // EMBEDDEDSHELLSURFACE_P_H

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -63,6 +63,6 @@ public:
   QString m_appIcon;
   QString m_label;
   QString m_icon;
-  int m_sortIndex;
+  uint32_t m_sortIndex;
 };
 #endif // EMBEDDEDSHELLSURFACE_P_H

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -2,7 +2,7 @@
 <protocol name="embedded_shell">
 	<copyright>
 	FIXME
-    </copyright>
+	</copyright>
 
 	<interface name="embedded_shell_surface" version="1">
 		<request name="destroy" type="destructor"></request>
@@ -42,7 +42,7 @@
 
 		<event name="configure">
 			<description summary="suggest resize">
-	    The configure event asks the client to resize its surface.
+		The configure event asks the client to resize its surface.
 		The width and height arguments specify the size of the window
 		in surface local coordinates.
 		</description>

--- a/quickembeddedshellwindow/CMakeLists.txt
+++ b/quickembeddedshellwindow/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(Qt6 REQUIRED COMPONENTS Core)
 qt_add_library(${PROJECT_NAME}
     quickembeddedshell.cpp quickembeddedshell.h
     quickembeddedshellwindow.cpp quickembeddedshellwindow.h
+    quickembeddedshellview.cpp quickembeddedshellview.h
     quickembeddedshellwindow_global.h
     waylandinputregion.cpp waylandinputregion.h
 )

--- a/quickembeddedshellwindow/quickembeddedshell.cpp
+++ b/quickembeddedshellwindow/quickembeddedshell.cpp
@@ -1,10 +1,12 @@
 #include "quickembeddedshell.h"
 #include "quickembeddedshellwindow.h"
+#include "quickembeddedshellview.h"
 #include "embeddedshellsurface.h"
 #include "waylandinputregion.h"
 
 void QuickEmbeddedShell::registerTypes(const char *uri) {
   qmlRegisterType<QuickEmbeddedShellWindow>(uri, 1, 0, "Window");
+  qmlRegisterType<QuickEmbeddedShellView>(uri, 1, 0, "View");
   qmlRegisterType<WaylandInputRegion>(uri, 1, 0, "WaylandInputRegion");
   qmlRegisterType<EmbeddedPlatform>(uri, 1, 0, "Platform");
   qmlRegisterUncreatableType<EmbeddedShellSurfaceView>(

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -1,0 +1,149 @@
+#include "quickembeddedshellview.h"
+#include "embeddedshellsurface.h"
+
+QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
+    : QQuickItem(parent)
+    , m_Window(nullptr)
+    , m_IsCurrentView(false)
+    , m_SortIndex(0)
+    , m_Completed(false)
+{
+}
+
+void QuickEmbeddedShellView::componentComplete()
+{
+  Q_ASSERT(m_Window);
+
+  if (m_Window->completed()) {
+    auto view = m_Window->createView(m_AppId, m_AppLabel, m_AppIcon, m_Label, m_Icon, m_SortIndex);
+    Q_ASSERT(view);
+
+    connect(view, &EmbeddedShellSurfaceView::selected, this, [view, this]() {
+      setIsCurrentView(true);
+    });
+    connect(view, &EmbeddedShellSurfaceView::deselected, this, [view, this]() {
+      setIsCurrentView(false);
+    });
+    connect(this, &QuickEmbeddedShellView::appLabelChanged, view, &EmbeddedShellSurfaceView::setAppLabel);
+    connect(this, &QuickEmbeddedShellView::appIconChanged, view, &EmbeddedShellSurfaceView::setAppIcon);
+    connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);
+    connect(this, &QuickEmbeddedShellView::iconChanged, view, &EmbeddedShellSurfaceView::setIcon);
+    connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, &EmbeddedShellSurfaceView::setSortIndex);
+    connect(this, &QObject::destroyed, view, &QObject::deleteLater);
+
+    m_Completed = true;
+  } else {
+    connect(m_Window, &QuickEmbeddedShellWindow::completedChanged, this, &QuickEmbeddedShellView::componentComplete, Qt::SingleShotConnection);
+  }
+
+  QQuickItem::componentComplete();
+}
+
+QuickEmbeddedShellWindow *QuickEmbeddedShellView::window() const
+{
+  return m_Window;
+}
+
+void QuickEmbeddedShellView::setWindow(QuickEmbeddedShellWindow *window)
+{
+  if (!m_Window && window) {
+    m_Window = window;
+    Q_EMIT quickEmbeddedShellWindowChanged(window);
+  }
+}
+
+bool QuickEmbeddedShellView::isCurrentView() const
+{
+  return m_IsCurrentView;
+}
+
+void QuickEmbeddedShellView::setIsCurrentView(bool isCurrentView)
+{
+  if (m_IsCurrentView != isCurrentView) {
+    m_IsCurrentView = isCurrentView;
+    Q_EMIT isCurrentViewChanged(isCurrentView);
+  }
+}
+
+QString QuickEmbeddedShellView::appId() const
+{
+  return m_AppId;
+}
+
+void QuickEmbeddedShellView::setAppId(const QString &appId)
+{
+  if (m_Completed) {
+    qCWarning(quickShell) << __PRETTY_FUNCTION__ << "AppId cannot be changed after the component has been completed!";
+    return;
+  }
+
+  if (m_AppId != appId) {
+    m_AppId = appId;
+    Q_EMIT appIdChanged(appId);
+  }
+}
+
+QString QuickEmbeddedShellView::appLabel() const
+{
+  return m_AppLabel;
+}
+
+void QuickEmbeddedShellView::setAppLabel(const QString &appLabel)
+{
+  if (m_AppLabel != appLabel) {
+    m_AppLabel = appLabel;
+    Q_EMIT appLabelChanged(appLabel);
+  }
+}
+
+QString QuickEmbeddedShellView::appIcon() const
+{
+  return m_AppIcon;
+}
+
+void QuickEmbeddedShellView::setAppIcon(const QString &appIcon)
+{
+  if (m_AppIcon != appIcon) {
+    m_AppIcon = appIcon;
+    Q_EMIT appIconChanged(appIcon);
+  }
+}
+
+QString QuickEmbeddedShellView::label() const
+{
+  return m_Label;
+}
+
+void QuickEmbeddedShellView::setLabel(const QString &label)
+{
+  if (m_Label != label) {
+    m_Label = label;
+    Q_EMIT labelChanged(label);
+  }
+}
+
+QString QuickEmbeddedShellView::icon() const
+{
+  return m_Icon;
+}
+
+void QuickEmbeddedShellView::setIcon(const QString &icon)
+{
+  if (m_Icon != icon) {
+    m_Icon = icon;
+    Q_EMIT iconChanged(icon);
+  }
+}
+
+quint32 QuickEmbeddedShellView::sortIndex() const
+{
+  return m_SortIndex;
+}
+
+void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
+{
+  if (m_SortIndex != sortIndex) {
+    m_SortIndex = sortIndex;
+    Q_EMIT sortIndexChanged(sortIndex);
+  }
+}

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -3,147 +3,152 @@
 
 QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
     : QQuickItem(parent)
-    , m_Window(nullptr)
-    , m_IsCurrentView(false)
-    , m_SortIndex(0)
-    , m_Completed(false)
+    , m_embeddedShellWindow(nullptr)
+    , m_isCurrentView(false)
+    , m_sortIndex(0)
+    , m_completed(false)
 {
 }
 
 void QuickEmbeddedShellView::componentComplete()
 {
-  Q_ASSERT(m_Window);
+  Q_ASSERT(m_embeddedShellWindow);
 
-  if (m_Window->completed()) {
-    auto view = m_Window->createView(m_AppId, m_AppLabel, m_AppIcon, m_Label, m_Icon, m_SortIndex);
-    Q_ASSERT(view);
-
-    connect(view, &EmbeddedShellSurfaceView::selected, this, [view, this]() {
-      setIsCurrentView(true);
-    });
-    connect(view, &EmbeddedShellSurfaceView::deselected, this, [view, this]() {
-      setIsCurrentView(false);
-    });
-    connect(this, &QuickEmbeddedShellView::appLabelChanged, view, &EmbeddedShellSurfaceView::setAppLabel);
-    connect(this, &QuickEmbeddedShellView::appIconChanged, view, &EmbeddedShellSurfaceView::setAppIcon);
-    connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);
-    connect(this, &QuickEmbeddedShellView::iconChanged, view, &EmbeddedShellSurfaceView::setIcon);
-    connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, &EmbeddedShellSurfaceView::setSortIndex);
-    connect(this, &QObject::destroyed, view, &QObject::deleteLater);
-
-    m_Completed = true;
+  if (m_embeddedShellWindow->completed()) {
+    createView();
   } else {
-    connect(m_Window, &QuickEmbeddedShellWindow::completedChanged, this, &QuickEmbeddedShellView::componentComplete, Qt::SingleShotConnection);
+    connect(m_embeddedShellWindow, &QuickEmbeddedShellWindow::completedChanged, this, &QuickEmbeddedShellView::createView, Qt::SingleShotConnection);
   }
 
   QQuickItem::componentComplete();
 }
 
-QuickEmbeddedShellWindow *QuickEmbeddedShellView::window() const
+QuickEmbeddedShellWindow *QuickEmbeddedShellView::embeddedShellWindow() const
 {
-  return m_Window;
+  return m_embeddedShellWindow;
 }
 
-void QuickEmbeddedShellView::setWindow(QuickEmbeddedShellWindow *window)
+void QuickEmbeddedShellView::setEmbeddedShellWindow(QuickEmbeddedShellWindow *embeddedShellWindow)
 {
-  if (!m_Window && window) {
-    m_Window = window;
-    Q_EMIT quickEmbeddedShellWindowChanged(window);
+  if (!m_embeddedShellWindow && embeddedShellWindow) {
+    m_embeddedShellWindow = embeddedShellWindow;
+    Q_EMIT embeddedShellWindowChanged(embeddedShellWindow);
   }
 }
 
 bool QuickEmbeddedShellView::isCurrentView() const
 {
-  return m_IsCurrentView;
+  return m_isCurrentView;
 }
 
 void QuickEmbeddedShellView::setIsCurrentView(bool isCurrentView)
 {
-  if (m_IsCurrentView != isCurrentView) {
-    m_IsCurrentView = isCurrentView;
+  if (m_isCurrentView != isCurrentView) {
+    m_isCurrentView = isCurrentView;
     Q_EMIT isCurrentViewChanged(isCurrentView);
   }
 }
 
+void QuickEmbeddedShellView::createView()
+{
+  auto view = m_embeddedShellWindow->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex);
+  Q_ASSERT(view);
+
+  connect(view, &EmbeddedShellSurfaceView::selected, this, [view, this]() {
+    setIsCurrentView(true);
+  });
+  connect(view, &EmbeddedShellSurfaceView::deselected, this, [view, this]() {
+    setIsCurrentView(false);
+  });
+  connect(this, &QuickEmbeddedShellView::appLabelChanged, view, &EmbeddedShellSurfaceView::setAppLabel);
+  connect(this, &QuickEmbeddedShellView::appIconChanged, view, &EmbeddedShellSurfaceView::setAppIcon);
+  connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);
+  connect(this, &QuickEmbeddedShellView::iconChanged, view, &EmbeddedShellSurfaceView::setIcon);
+  connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, &EmbeddedShellSurfaceView::setSortIndex);
+  connect(this, &QObject::destroyed, view, &QObject::deleteLater);
+
+  m_completed = true;
+}
+
 QString QuickEmbeddedShellView::appId() const
 {
-  return m_AppId;
+  return m_appId;
 }
 
 void QuickEmbeddedShellView::setAppId(const QString &appId)
 {
-  if (m_Completed) {
+  if (m_completed) {
     qCWarning(quickShell) << __PRETTY_FUNCTION__ << "AppId cannot be changed after the component has been completed!";
     return;
   }
 
-  if (m_AppId != appId) {
-    m_AppId = appId;
+  if (m_appId != appId) {
+    m_appId = appId;
     Q_EMIT appIdChanged(appId);
   }
 }
 
 QString QuickEmbeddedShellView::appLabel() const
 {
-  return m_AppLabel;
+  return m_appLabel;
 }
 
 void QuickEmbeddedShellView::setAppLabel(const QString &appLabel)
 {
-  if (m_AppLabel != appLabel) {
-    m_AppLabel = appLabel;
+  if (m_appLabel != appLabel) {
+    m_appLabel = appLabel;
     Q_EMIT appLabelChanged(appLabel);
   }
 }
 
 QString QuickEmbeddedShellView::appIcon() const
 {
-  return m_AppIcon;
+  return m_appIcon;
 }
 
 void QuickEmbeddedShellView::setAppIcon(const QString &appIcon)
 {
-  if (m_AppIcon != appIcon) {
-    m_AppIcon = appIcon;
+  if (m_appIcon != appIcon) {
+    m_appIcon = appIcon;
     Q_EMIT appIconChanged(appIcon);
   }
 }
 
 QString QuickEmbeddedShellView::label() const
 {
-  return m_Label;
+  return m_label;
 }
 
 void QuickEmbeddedShellView::setLabel(const QString &label)
 {
-  if (m_Label != label) {
-    m_Label = label;
+  if (m_label != label) {
+    m_label = label;
     Q_EMIT labelChanged(label);
   }
 }
 
 QString QuickEmbeddedShellView::icon() const
 {
-  return m_Icon;
+  return m_icon;
 }
 
 void QuickEmbeddedShellView::setIcon(const QString &icon)
 {
-  if (m_Icon != icon) {
-    m_Icon = icon;
+  if (m_icon != icon) {
+    m_icon = icon;
     Q_EMIT iconChanged(icon);
   }
 }
 
 quint32 QuickEmbeddedShellView::sortIndex() const
 {
-  return m_SortIndex;
+  return m_sortIndex;
 }
 
 void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
 {
-  if (m_SortIndex != sortIndex) {
-    m_SortIndex = sortIndex;
+  if (m_sortIndex != sortIndex) {
+    m_sortIndex = sortIndex;
     Q_EMIT sortIndexChanged(sortIndex);
   }
 }

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef QUICKEMBEDDEDSHELLVIEW_H
+#define QUICKEMBEDDEDSHELLVIEW_H
+
+#include "quickembeddedshellwindow.h"
+#include "quickembeddedshellwindow_global.h"
+
+#include <QQuickItem>
+
+class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
+{
+  Q_OBJECT
+
+  Q_PROPERTY(QuickEmbeddedShellWindow *window READ window WRITE setWindow NOTIFY quickEmbeddedShellWindowChanged)
+  Q_PROPERTY(bool isCurrentView READ isCurrentView NOTIFY isCurrentViewChanged)
+
+  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged);
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged);
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged);
+  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged);
+  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged);
+  Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged);
+
+public:
+  explicit QuickEmbeddedShellView(QQuickItem *parent = nullptr);
+
+  void componentComplete() override;
+
+  QuickEmbeddedShellWindow *window() const;
+  void setWindow(QuickEmbeddedShellWindow *window);
+
+  bool isCurrentView() const;
+
+  QString appId() const;
+  void setAppId(const QString &appId);
+
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+
+  QString label() const;
+  void setLabel(const QString &label);
+
+  QString icon() const;
+  void setIcon(const QString &icon);
+
+  quint32 sortIndex() const;
+  void setSortIndex(quint32 sortIndex);
+
+signals:
+  void quickEmbeddedShellWindowChanged(QuickEmbeddedShellWindow *window);
+  void isCurrentViewChanged(bool isCurrentView);
+  void appIdChanged(const QString &appId);
+  void appLabelChanged(const QString &appLabel);
+  void appIconChanged(const QString &appIcon);
+  void labelChanged(const QString &label);
+  void iconChanged(const QString &icon);
+  void sortIndexChanged(quint32 sortIndex);
+
+private:
+  void setIsCurrentView(bool isCurrentView);
+
+private:
+  QuickEmbeddedShellWindow *m_Window;
+  bool m_IsCurrentView;
+
+  QString m_AppId;
+  QString m_AppLabel;
+  QString m_AppIcon;
+  QString m_Label;
+  QString m_Icon;
+  quint32 m_SortIndex;
+  bool m_Completed;
+};
+
+#endif // QUICKEMBEDDEDSHELLVIEW_H

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -12,23 +12,23 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
 {
   Q_OBJECT
 
-  Q_PROPERTY(QuickEmbeddedShellWindow *window READ window WRITE setWindow NOTIFY quickEmbeddedShellWindowChanged)
+  Q_PROPERTY(QuickEmbeddedShellWindow *embeddedShellWindow READ embeddedShellWindow WRITE setEmbeddedShellWindow NOTIFY embeddedShellWindowChanged)
   Q_PROPERTY(bool isCurrentView READ isCurrentView NOTIFY isCurrentViewChanged)
 
-  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged);
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged);
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged);
-  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged);
-  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged);
-  Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged);
+  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
+  Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
 
 public:
   explicit QuickEmbeddedShellView(QQuickItem *parent = nullptr);
 
   void componentComplete() override;
 
-  QuickEmbeddedShellWindow *window() const;
-  void setWindow(QuickEmbeddedShellWindow *window);
+  QuickEmbeddedShellWindow *embeddedShellWindow() const;
+  void setEmbeddedShellWindow(QuickEmbeddedShellWindow *embeddedShellWindow);
 
   bool isCurrentView() const;
 
@@ -51,7 +51,7 @@ public:
   void setSortIndex(quint32 sortIndex);
 
 signals:
-  void quickEmbeddedShellWindowChanged(QuickEmbeddedShellWindow *window);
+  void embeddedShellWindowChanged(QuickEmbeddedShellWindow *embeddedShellWindow);
   void isCurrentViewChanged(bool isCurrentView);
   void appIdChanged(const QString &appId);
   void appLabelChanged(const QString &appLabel);
@@ -62,18 +62,18 @@ signals:
 
 private:
   void setIsCurrentView(bool isCurrentView);
+  void createView();
 
-private:
-  QuickEmbeddedShellWindow *m_Window;
-  bool m_IsCurrentView;
+  QuickEmbeddedShellWindow *m_embeddedShellWindow;
+  bool m_isCurrentView;
 
-  QString m_AppId;
-  QString m_AppLabel;
-  QString m_AppIcon;
-  QString m_Label;
-  QString m_Icon;
-  quint32 m_SortIndex;
-  bool m_Completed;
+  QString m_appId;
+  QString m_appLabel;
+  QString m_appIcon;
+  QString m_label;
+  QString m_icon;
+  quint32 m_sortIndex;
+  bool m_completed;
 };
 
 #endif // QUICKEMBEDDEDSHELLVIEW_H

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -7,18 +7,21 @@ Q_LOGGING_CATEGORY(quickShell, "embeddedshell.quick")
 
 QuickEmbeddedShellWindow::QuickEmbeddedShellWindow(QWindow *parent)
     : QQuickWindow(parent)
-    , m_size(QSize{0, 0}) {
+    , m_size(QSize{0, 0})
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }
 
 QuickEmbeddedShellWindow::~QuickEmbeddedShellWindow() {}
 
-EmbeddedShellTypes::Anchor QuickEmbeddedShellWindow::anchor() const {
+EmbeddedShellTypes::Anchor QuickEmbeddedShellWindow::anchor() const
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor;
   return m_anchor;
 }
 
-void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor) {
+void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
   if (m_anchor == newAnchor)
     return;
@@ -29,23 +32,32 @@ void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor) {
 EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &appId,
                                                                const QString &appLabel,
                                                                const QString &label,
-                                                               unsigned int sort_index) {
+                                                               unsigned int sort_index)
+{
   auto view = m_surface->createView(appId, appLabel, label, sort_index);
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
   return view;
 }
 
-EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& appId, const QString& appLabel, const QString& appIcon, const QString& label, const QString& icon, uint32_t sort_index){
-    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
-    return view;
+EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& appId,
+                                                               const QString& appLabel,
+                                                               const QString& appIcon,
+                                                               const QString& label,
+                                                               const QString& icon,
+                                                               uint32_t sort_index)
+{
+  auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
+  return view;
 }
 
-void QuickEmbeddedShellWindow::classBegin() {
+void QuickEmbeddedShellWindow::classBegin()
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }
 
-void QuickEmbeddedShellWindow::componentComplete() {
+void QuickEmbeddedShellWindow::componentComplete()
+{
   m_surface = EmbeddedPlatform::shellSurfaceForWindow(this);
 
   if (m_surface != nullptr) {
@@ -56,15 +68,18 @@ void QuickEmbeddedShellWindow::componentComplete() {
     }
   }
   m_componentComplete = true;
+  emit completedChanged(m_componentComplete);
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_surface;
 }
 
-int QuickEmbeddedShellWindow::implicitWidth() const {
+int QuickEmbeddedShellWindow::implicitWidth() const
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.width();
   return m_size.width();
 }
 
-void QuickEmbeddedShellWindow::setImplicitWidth(int implicitWidth) {
+void QuickEmbeddedShellWindow::setImplicitWidth(int implicitWidth)
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitWidth;
   const QSize newSize{implicitWidth, m_size.height()};
   if (m_size == newSize) {
@@ -77,12 +92,14 @@ void QuickEmbeddedShellWindow::setImplicitWidth(int implicitWidth) {
   }
 }
 
-int QuickEmbeddedShellWindow::implicitHeight() const {
+int QuickEmbeddedShellWindow::implicitHeight() const
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.height();
   return m_size.height();
 }
 
-void QuickEmbeddedShellWindow::setImplicitHeight(int implicitHeight) {
+void QuickEmbeddedShellWindow::setImplicitHeight(int implicitHeight)
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitHeight;
   const QSize newSize{m_size.width(), implicitHeight};
   if (m_size == newSize) {
@@ -95,12 +112,14 @@ void QuickEmbeddedShellWindow::setImplicitHeight(int implicitHeight) {
   }
 }
 
-int QuickEmbeddedShellWindow::margin() const {
+int QuickEmbeddedShellWindow::margin() const
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_margin;
   return m_margin;
 }
 
-void QuickEmbeddedShellWindow::setMargin(int newMargin) {
+void QuickEmbeddedShellWindow::setMargin(int newMargin)
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << newMargin;
   if (m_margin == newMargin)
     return;
@@ -108,12 +127,21 @@ void QuickEmbeddedShellWindow::setMargin(int newMargin) {
   emit marginChanged(newMargin);
 }
 
-unsigned int QuickEmbeddedShellWindow::sortIndex() const { return m_sortIndex; }
+unsigned int QuickEmbeddedShellWindow::sortIndex() const
+{
+  return m_sortIndex;
+}
 
-void QuickEmbeddedShellWindow::setSortIndex(unsigned int sortIndex) {
+void QuickEmbeddedShellWindow::setSortIndex(unsigned int sortIndex)
+{
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
   if (m_sortIndex == sortIndex)
     return;
   m_sortIndex = sortIndex;
   emit sortIndexChanged(sortIndex);
+}
+
+bool QuickEmbeddedShellWindow::completed() const
+{
+  return m_componentComplete;
 }

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -34,9 +34,14 @@ EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &ap
                                                                const QString &label,
                                                                unsigned int sort_index)
 {
-  auto view = m_surface->createView(appId, appLabel, label, sort_index);
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
-  return view;
+  if (m_surface) {
+    auto view = m_surface->createView(appId, appLabel, label, sort_index);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
+    return view;
+  } else {
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    return nullptr;
+  }
 }
 
 EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& appId,
@@ -46,9 +51,14 @@ EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& ap
                                                                const QString& icon,
                                                                uint32_t sort_index)
 {
-  auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
-  return view;
+  if (m_surface) {
+    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
+    return view;
+  } else {
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    return nullptr;
+  }
 }
 
 void QuickEmbeddedShellWindow::classBegin()
@@ -60,7 +70,7 @@ void QuickEmbeddedShellWindow::componentComplete()
 {
   m_surface = EmbeddedPlatform::shellSurfaceForWindow(this);
 
-  if (m_surface != nullptr) {
+  if (m_surface) {
     m_surface->sendAnchor(m_anchor);
     m_surface->sendMargin(m_margin);
     if (m_size.isValid()) {

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -30,7 +30,8 @@ public:
                  NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
   Q_PROPERTY(
-     unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+      unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
 
   EmbeddedShellTypes::Anchor anchor() const;
   void setAnchor(EmbeddedShellTypes::Anchor newAnchor);
@@ -47,6 +48,7 @@ public:
   void setMargin(int newMargin);
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
+  bool completed() const;
 
 public slots:
   EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, unsigned int sort_index);
@@ -63,6 +65,7 @@ signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sortIndex);
+  void completedChanged(bool completed);
 
 private:
   QSize m_size;


### PR DESCRIPTION
…pport for virtual surface view removal

Added QuickEmbeddedShellView as a declarative qml wrapper for EmbeddedShellSurfaceView similar to what QuickEmbeddedShellWindow does for EmbeddedShellSurface.

Added a deselect method to EmbeddedShellSurfaceView to notify previous views about deseletion when a new view is selected.

Implemented handling of sort index updates for virtual surface views.

Extended QuickEmbeddedShellWindow interface with a completed property to be able to notify the respective QuickEmbeddedShellViews about component completion (which is required to access the wayland surface before the actual EmbeddedShellSurface instance can be created internally).