### PR TITLE
Add qml api for QuickEmbeddedShellSurface

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,18 @@ There is an alternative method to detect shell surface creation which is waiting
 
 ```
 
-For convenience of QML applications, we also implement a QML interface to embedded_shell_surface, which is implemented in the sub project "quickembeddedshellwindow" (see [.h](/quickembeddedshellwindow/quickembeddedshellwindow.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellwindow.cpp))
+For convenience of QML applications, we also implement a QML interface to embedded_shell_surface, which is implemented in the sub project "quickembeddedshellwindow" (see [.h](/quickembeddedshellwindow/quickembeddedshellwindow.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellwindow.cpp)).
 
 ```qml
-    import EmbeddedShell 1.0
+    import EmbeddedShell
     Window {
         id: myWindow
         visible: true
         title: qsTr("Hello from CenterClient")
-        anchor: Window.Anchor.Center
+        surface.anchor: Surface.Anchor.Center
         color: "darkgray"
         width: 200
-        height:200
+        height: 200
         MouseArea {
             anchors.fill: parent
             onClicked: {
@@ -135,29 +135,50 @@ For convenience of QML applications, we also implement a QML interface to embedd
                 var appLabel = "My App"
                 var label = "My View"
                 var sortIndex = 0
-                var view = myWindow.createView(appId, appLabel, label, sortIndex);
+                var view = myWindow.surface.createView(appId, appLabel, label, sortIndex);
                 view.selected.connect(function(){ console.log("view", view.label, "was selected"); })
             }
         }
     }
 ```
 
-A declarative QML interface to embedded_shell_surface_view is also available (see [.h](/quickembeddedshellwindow/quickembeddedshellview.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellview.cpp))
+If a different QWindow-based class is needed (for example, from Qt Quick Controls), the surface can also be creted using a dedicated QML interface provided by the "quickembeddedshellwindow" subproject (see [.h](/quickembeddedshellwindow/quickembeddedshellsurface.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellsurface.cpp)).
 
 ```qml
-    import EmbeddedShell 1.0
+    import QtQuick.Controls
+    import EmbeddedShell
+    ApplicationWindow {
+        id: myWindow
+        visible: true
+        title: qsTr("Hello from CenterClient")
+        
+        Surface {
+            window: myWindow
+            anchor: Surface.Anchor.Center
+        }
+        
+        color: "darkgray"
+        width: 200
+        height: 200
+    }
+```
+
+A declarative QML interface to embedded_shell_surface_view is also available (see [.h](/quickembeddedshellwindow/quickembeddedshellview.h), [.cpp](/quickembeddedshellwindow/quickembeddedshellview.cpp)).
+
+```qml
+    import EmbeddedShell
     Window {
         id: myWindow
         visible: true
         title: qsTr("Hello from CenterClient")
-        anchor: Window.Anchor.Center
+        surface.anchor: Surface.Anchor.Center
         color: "darkgray"
         width: 200
-        height:200
+        height: 200
         
         View {
             id: myView
-            embeddedShellWindow: myWindow
+            surface: myWindow.surface
             appId: "MyApp"
             appLabel: "My App"
             label: "My View"

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For convenience of QML applications, we also implement a QML interface to embedd
                 var label = "My View"
                 var sortIndex = 0
                 var view = myWindow.surface.createView(appId, appLabel, label, sortIndex);
-                view.selected.connect(function(){ console.log("view", view.label, "was selected"); })
+                view.selectedChanged.connect(function(){ if (view.selected) console.log("view", view.label, "was selected"); })
             }
         }
     }

--- a/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
+++ b/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
@@ -3,6 +3,7 @@
 #include "mainwindow.h"
 #include "embeddedplatform.h"
 #include "embeddedshellsurface.h"
+#include "embeddedshellsurfaceview.h"
 #include "qscreen.h"
 #include <QDebug>
 #include <QLabel>

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -145,6 +145,15 @@ void TaskSwitcherDBusInterface::onViewsInserted(const QModelIndex &parent, int f
             connect(view, &EmbeddedShellSurfaceView::labelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
             connect(view, &EmbeddedShellSurfaceView::iconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
         }
+
+        if (auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>()) {
+            if (m_ConnectedEmbeddedShellSurfaces[surface] == 0) {
+                connect(surface, &EmbeddedShellSurface::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+                connect(surface, &EmbeddedShellSurface::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+            }
+
+            m_ConnectedEmbeddedShellSurfaces[surface]++;
+        }
     }
 }
 
@@ -161,6 +170,15 @@ void TaskSwitcherDBusInterface::onViewsAboutToBeRemoved(const QModelIndex &paren
             disconnect(view, &EmbeddedShellSurfaceView::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
             disconnect(view, &EmbeddedShellSurfaceView::labelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
             disconnect(view, &EmbeddedShellSurfaceView::iconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+        }
+
+        if (auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>()) {
+          m_ConnectedEmbeddedShellSurfaces[surface]--;
+
+          if (m_ConnectedEmbeddedShellSurfaces[surface] == 0) {
+            disconnect(surface, &EmbeddedShellSurface::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+            disconnect(surface, &EmbeddedShellSurface::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+          }
         }
     }
 }

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
@@ -10,6 +10,7 @@
 #include <QList>
 #include <QAbstractListModel>
 
+class EmbeddedShellSurface;
 
 class TaskSwitcherDBusInterface : public DBusInterface
 {
@@ -51,4 +52,5 @@ private:
 
     QString m_currentView;
     QAbstractListModel *m_viewModel = nullptr;
+    QHash<EmbeddedShellSurface *, int> m_ConnectedEmbeddedShellSurfaces;
 };

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -128,6 +128,11 @@ void EmbeddedShellSurface::sendConfigure(const QSize size) {
   send_configure(size.width(), size.height());
 }
 
+void EmbeddedShellSurface::sendVisibleChanged(bool visible) {
+  qCDebug(shellExt) << __PRETTY_FUNCTION__ << visible;
+  send_visible_changed(visible);
+}
+
 QString EmbeddedShellSurface::getUuid() const {
   return m_uuid.toString(QUuid::WithoutBraces);
 }

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -67,8 +67,7 @@ public:
   QString appLabel() const { return m_appLabel; }
   QString appIcon() const { return m_appIcon; }
   Q_PROPERTY(QSize size READ getSize NOTIFY sizeChanged)
-  Q_PROPERTY(
-      EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
+  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QString appId READ appId CONSTANT)
@@ -84,6 +83,7 @@ public:
   void setAppLabel(const QString &appLabel);
   void setAppIcon(const QString &appIcon);
   Q_INVOKABLE void sendConfigure(const QSize size);
+  Q_INVOKABLE void sendVisibleChanged(bool visible);
   QString getUuid() const;
   pid_t getClientPid() const;
 

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -233,6 +233,7 @@ WaylandCompositor {
 
     ListModel {
         id: centerApplicationViewModel
+
         property var surfaces: ({});
 
         function addSurface(shellSurface, shellSurfaceItem) {
@@ -266,20 +267,6 @@ WaylandCompositor {
         function createView(shellSurface, view) {
             var entry = surfaces[shellSurface];
             console.log("compositor: create view! "+ view +" have entry "+entry);
-            if(entry.views.length === 0) {
-                console.log("setting first view!");
-                entry.views.push(view);
-                append({data: {view: view, surface: shellSurface}});
-                for (var i = 0; i < count; i++) {
-                    if(get(i).data.surface === shellSurface) {
-                        remove(i);
-                        break;
-                    }
-                }
-                if (centerArea.surfaceItem.shellSurface === shellSurface)
-                    centerArea.selectSurface(shellSurface, view);
-                return;
-            }
 
             view.aboutToBeDestroyed.connect(function() {
                 for (var i = 0; i < count; i++) {
@@ -299,12 +286,30 @@ WaylandCompositor {
                             entry.views.splice(index, 1);
                         }
 
-                        break;
+                        return;
                     }
                 }
+
+                console.warn("view", view, "not found in view model!")
             });
 
             append({data: {view: view, surface: shellSurface}});
+
+            if(entry.views.length === 0) {
+                console.log("setting first view!");
+                entry.views.push(view);
+
+                for (var i = 0; i < count; i++) {
+                    if(get(i).data.surface === shellSurface && !get(i).data.view) {
+                        remove(i);
+                        break;
+                    }
+                }
+
+                if (centerArea.surfaceItem.shellSurface === shellSurface) {
+                    centerArea.selectSurface(shellSurface, view);
+                }
+            }
         }
 
         function findByUuid(uuid) {
@@ -419,7 +424,12 @@ WaylandCompositor {
         viewModel: centerApplicationViewModel
         onCurrentViewChanged: {
             var entry = centerApplicationViewModel.findByUuid(currentView);
-            centerArea.selectSurface(entry.surface, entry.view);
+
+            if (entry) {
+                centerArea.selectSurface(entry.surface, entry.view);
+            } else {
+                console.warn("Could not find", currentView, "in centerApplicationViewModel!");
+            }
         }
     }
 

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -266,7 +266,7 @@ WaylandCompositor {
 
         function createView(shellSurface, view) {
             var entry = surfaces[shellSurface];
-            console.log("compositor: create view! "+ view +" have entry "+entry);
+            console.log("compositor: create view", view , "with entry", entry);
 
             view.aboutToBeDestroyed.connect(function() {
                 for (var i = 0; i < count; i++) {
@@ -274,6 +274,10 @@ WaylandCompositor {
                     if (data.view === view) {
                         var surface = data.surface;
                         remove(i);
+
+                        if (!findByUuid(data.surface.uuid)) {
+                            append({data: {view: null, surface: shellSurface}});
+                        }
 
                         // Fall back to uuid of surface
                         if (taskSwitcherInterface.currentView === view.uuid) {
@@ -300,7 +304,8 @@ WaylandCompositor {
                 entry.views.push(view);
 
                 for (var i = 0; i < count; i++) {
-                    if(get(i).data.surface === shellSurface && !get(i).data.view) {
+                    var data = get(i).data
+                    if(data.surface === shellSurface && !data.view) {
                         remove(i);
                         break;
                     }

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -333,21 +333,30 @@ WaylandCompositor {
         ShellSurfaceItem {
             id: shellSurfaceItem
 
-            visible: parent.surfaceItem === shellSurfaceItem
+            property bool isCurrentSurface: parent.surfaceItem === shellSurfaceItem
+            visible: isCurrentSurface
 
             onSurfaceDestroyed:  destroy()
             onWidthChanged: Qt.callLater(handleResized)
             onHeightChanged: Qt.callLater(handleResized)
             Component.onCompleted: {
                 handleAnchor();
+                updateVisibility();
             }
 
             property int margin: shellSurface.margin
             property string uuid: currentView ? currentView.uuid : shellSurface.uuid
             property var currentView: null
 
-            onCurrentViewChanged: if(currentView != null) currentView.select();
+            onCurrentViewChanged: {
+                if(currentView != null) {
+                    currentView.select();
+                }
+            }
 
+            onIsCurrentSurfaceChanged: {
+                updateVisibility();
+            }
 
             Connections {
                 target: shellSurface
@@ -361,6 +370,12 @@ WaylandCompositor {
 
                 function onCreateView(view) {
                     centerApplicationViewModel.createView(shellSurface, view);
+                }
+            }
+
+            function updateVisibility() {
+                if (shellSurface) {
+                    shellSurface.sendVisibleChanged(isCurrentSurface);
                 }
             }
 

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -407,7 +407,9 @@ WaylandCompositor {
     }
 
     EmbeddedShell {
-        onSurfaceAdded: chromeComponent.createObject(limboArea, { "shellSurface": surface } );
+        onSurfaceAdded: (surface) => {
+            chromeComponent.createObject(limboArea, { "shellSurface": surface } );
+        }
     }
 
     TaskSwitcherInterface {

--- a/embeddedplatform/CMakeLists.txt
+++ b/embeddedplatform/CMakeLists.txt
@@ -12,6 +12,7 @@ qt_add_library(${PROJECT_NAME}
     embeddedshellanchor.h
     embeddedshelltypes.h
     embeddedshellsurface.cpp embeddedshellsurface.h embeddedshellsurface_p.h
+    embeddedshellsurfaceview.cpp embeddedshellsurfaceview.h embeddedshellsurfaceview_p.h
 )
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
@@ -80,6 +81,7 @@ set(INTERFACE_HEADERS
     embeddedshelltypes.h
     embeddedshellanchor.h
     embeddedshellsurface.h
+    embeddedshellsurfaceview.h
     embeddedcompositordbusclient.h)
 
 install(FILES ${INTERFACE_HEADERS}

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -2,9 +2,9 @@
 
 #include "embeddedshellsurface.h"
 #include "embeddedshellsurface_p.h"
+#include "embeddedshellsurfaceview.h"
+#include "embeddedshellsurfaceview_p.h"
 #include <QtWaylandClient/private/qwaylandwindow_p.h>
-#include <qpa/qplatformwindow.h>
-#include <qpa/qwindowsysteminterface.h>
 
 EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
                                            QtWaylandClient::QWaylandWindow *window,
@@ -131,13 +131,15 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
   viewPrivate->m_icon = icon;
   viewPrivate->m_sortIndex = sort_index;
 
-  connect(view, &EmbeddedShellSurfaceView::selected, d, [view, d]() {
-    if (d->m_selectedView != view) {
-      if (d->m_selectedView) {
-        d->m_selectedView->deselected();
-      }
+  connect(view, &EmbeddedShellSurfaceView::selectedChanged, d, [view, d](bool selected) {
+    if (selected) {
+      if (d->m_selectedView != view) {
+        if (d->m_selectedView) {
+          d->m_selectedView->setSelected(false);
+        }
 
-      d->m_selectedView = view;
+        d->m_selectedView = view;
+      }
     }
   });
 
@@ -190,117 +192,4 @@ void EmbeddedShellSurface::sendAppIcon(const QString &appIcon)
 {
   Q_D(EmbeddedShellSurface);
   d->set_app_icon(appIcon);
-}
-
-EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
-                                                                 ::surface_view *view,
-                                                                 EmbeddedShellSurface *surf)
-    : QObject(surf)
-    , QtWayland::surface_view(view)
-    , q_ptr(q)
-    , m_sortIndex(0)
-{
-}
-
-EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate()
-{
-  destroy();
-}
-
-EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedShellSurfaceView *q)
-{
-  return q->d_func();
-}
-
-void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
-{
-  qDebug() << __PRETTY_FUNCTION__;
-  Q_Q(EmbeddedShellSurfaceView);
-  emit q->selected();
-}
-
-EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
-                                                   EmbeddedShellSurface *surf)
-    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf))
-{
-}
-
-QString EmbeddedShellSurfaceView::appLabel() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_appLabel;
-}
-
-void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_appLabel == appLabel)
-    return;
-  d->m_appLabel = appLabel;
-  d->set_app_label(appLabel);
-  Q_EMIT appLabelChanged(appLabel);
-}
-
-QString EmbeddedShellSurfaceView::appIcon() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_appIcon;
-}
-
-void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_appIcon == appIcon)
-    return;
-  d->m_appIcon = appIcon;
-  d->set_app_icon(appIcon);
-  Q_EMIT appIconChanged(appIcon);
-}
-
-QString EmbeddedShellSurfaceView::label() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_label;
-}
-
-void EmbeddedShellSurfaceView::setLabel(const QString &label)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_label == label)
-    return;
-  d->m_label = label;
-  d->set_label(label);
-  Q_EMIT labelChanged(label);
-}
-
-QString EmbeddedShellSurfaceView::icon() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_icon;
-}
-
-void EmbeddedShellSurfaceView::setIcon(const QString &icon)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_icon == icon)
-    return;
-  d->m_icon = icon;
-  d->set_icon(icon);
-  Q_EMIT iconChanged(icon);
-}
-
-unsigned int EmbeddedShellSurfaceView::sortIndex() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_sortIndex;
-}
-
-void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_sortIndex == sortIndex)
-    return;
-  d->m_sortIndex = sortIndex;
-  d->set_sort_index(sortIndex);
-  Q_EMIT sortIndexChanged(sortIndex);
 }

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -12,7 +12,8 @@ EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shel
                                            EmbeddedShellTypes::Anchor anchor,
                                            uint32_t margin,
                                            uint32_t sort_index)
-    : d_ptr(new EmbeddedShellSurfacePrivate(shell_surface,
+    : d_ptr(new EmbeddedShellSurfacePrivate(this,
+                                            shell_surface,
                                             window,
                                             size,
                                             anchor,
@@ -21,7 +22,8 @@ EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shel
 {
 }
 
-EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
+EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(EmbeddedShellSurface *q,
+                                                         struct ::embedded_shell_surface *shell_surface,
                                                          QtWaylandClient::QWaylandWindow *window,
                                                          const QSize &size,
                                                          EmbeddedShellTypes::Anchor anchor,
@@ -33,6 +35,7 @@ EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(struct ::embedded_shell
     , m_anchor(anchor)
     , m_margin(margin)
     , m_sort_index(sort_index)
+    , q_ptr(q)
 {
 }
 
@@ -58,6 +61,12 @@ unsigned int EmbeddedShellSurface::getSortIndex() const
   return d->m_sort_index;
 }
 
+bool EmbeddedShellSurface::getVisible()
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_visible;
+}
+
 void EmbeddedShellSurfacePrivate::applyConfigure()
 {
   window()->resizeFromApplyConfigure(m_pendingSize);
@@ -68,6 +77,16 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_configure(int32_t width
 {
   m_pendingSize = {width, height};
   window()->applyConfigureWhenPossible();
+}
+
+void EmbeddedShellSurfacePrivate::embedded_shell_surface_visible_changed(int32_t visible)
+{
+  Q_Q(EmbeddedShellSurface);
+  auto bVisible = static_cast<bool>(visible);
+  if (m_visible != bVisible) {
+    m_visible = bVisible;
+    emit q->visibleChanged(bVisible);
+  }
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -36,6 +36,8 @@ public:
   QSize getSize() const;
   EmbeddedShellTypes::Anchor getAnchor() const;
   unsigned int getSortIndex() const;
+  bool getVisible();
+
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
                                        uint32_t sort_index);
@@ -51,7 +53,9 @@ public:
                                        uint32_t sort_index);
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();
+
 signals:
+  void visibleChanged(bool visible);
 
 public slots:
   void sendSize(const QSize &size);
@@ -68,7 +72,11 @@ class EmbeddedShellSurfaceView : public QObject
   Q_OBJECT
   Q_DECLARE_PRIVATE(EmbeddedShellSurfaceView)
   QScopedPointer<EmbeddedShellSurfaceViewPrivate> d_ptr;
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
+  Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
 
 public:
   QString appLabel() const;

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -8,16 +8,13 @@
 #include <QObject>
 
 class EmbeddedShellSurfaceView;
-class EmbeddedShellSurfaceViewPrivate;
 class EmbeddedShellSurfacePrivate;
 
 struct embedded_shell_surface;
-struct surface_view;
-class QWindow;
 
 namespace QtWaylandClient {
-class QWaylandWindow;
-class QWaylandShellSurface;
+  class QWaylandWindow;
+  class QWaylandShellSurface;
 } // namespace QtWaylandClient
 
 class Q_DECL_EXPORT EmbeddedShellSurface : public QObject
@@ -65,48 +62,6 @@ public slots:
   void sendAppId(const QString &appId);
   void sendAppLabel(const QString &appLabe);
   void sendAppIcon(const QString &appIcon);
-};
-
-class EmbeddedShellSurfaceView : public QObject
-{
-  Q_OBJECT
-  Q_DECLARE_PRIVATE(EmbeddedShellSurfaceView)
-  QScopedPointer<EmbeddedShellSurfaceViewPrivate> d_ptr;
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
-  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
-  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
-  Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-
-public:
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-  Q_SIGNAL void appLabelChanged(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
-  Q_SIGNAL void appIconChanged(const QString &appIcon);
-
-  QString label() const;
-  void setLabel(const QString &label);
-  Q_SIGNAL void labelChanged(const QString &label);
-
-  QString icon() const;
-  void setIcon(const QString &icon);
-  Q_SIGNAL void iconChanged(const QString &icon);
-
-  unsigned int sortIndex() const;
-  void setSortIndex(unsigned int sortIndex);
-  Q_SIGNAL void sortIndexChanged(unsigned int sortIndex);
-
-signals:
-  void selected();
-  void deselected();
-
-private:
-  friend class EmbeddedShellSurface;
-  EmbeddedShellSurfaceView(struct ::surface_view *view,
-                           EmbeddedShellSurface *surf);
 };
 
 #endif // EMBEDDEDSHELLSURFACE_H

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -5,15 +5,16 @@
 
 #include "embeddedshellsurface.h"
 #include "qwayland-embedded-shell.h"
-#include <QDebug>
+
 #include <QPointer>
 #include <QtWaylandClient/private/qwaylandshellsurface_p.h>
 
-class EmbeddedShellSurfacePrivate
-    : public QtWaylandClient::QWaylandShellSurface,
-      public QtWayland::embedded_shell_surface {
+class EmbeddedShellSurfacePrivate : public QtWaylandClient::QWaylandShellSurface,
+                                    public QtWayland::embedded_shell_surface
+{
   Q_DECLARE_PUBLIC(EmbeddedShellSurface)
   Q_OBJECT
+
 public:
   EmbeddedShellSurfacePrivate(EmbeddedShellSurface *q,
                               struct ::embedded_shell_surface *shell_surface,
@@ -21,7 +22,9 @@ public:
                               const QSize &size,
                               EmbeddedShellTypes::Anchor anchor,
                               uint32_t margin, uint32_t sort_index);
+
   ~EmbeddedShellSurfacePrivate() override;
+
   QSize getSize() const { return m_size; }
   EmbeddedShellTypes::Anchor getAnchor() const { return m_anchor; }
   uint32_t getMargin() const { return m_margin; }
@@ -43,29 +46,4 @@ protected:
   void embedded_shell_surface_visible_changed(int32_t visible) override;
 };
 
-class EmbeddedShellSurfaceViewPrivate : public QObject,
-                                        public QtWayland::surface_view {
-  Q_DECLARE_PUBLIC(EmbeddedShellSurfaceView)
-  Q_OBJECT
-
-public:
-  EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
-                                  ::surface_view *view,
-                                  EmbeddedShellSurface *surf);
-
-  ~EmbeddedShellSurfaceViewPrivate() override;
-
-  static EmbeddedShellSurfaceViewPrivate *get(EmbeddedShellSurfaceView *q);
-
-  void surface_view_selected() override;
-
-  EmbeddedShellSurfaceView *q_ptr = nullptr;
-
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
-  QString m_label;
-  QString m_icon;
-  uint32_t m_sortIndex;
-};
 #endif // EMBEDDEDSHELLSURFACE_P_H

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -15,7 +15,8 @@ class EmbeddedShellSurfacePrivate
   Q_DECLARE_PUBLIC(EmbeddedShellSurface)
   Q_OBJECT
 public:
-  EmbeddedShellSurfacePrivate(struct ::embedded_shell_surface *shell_surface,
+  EmbeddedShellSurfacePrivate(EmbeddedShellSurface *q,
+                              struct ::embedded_shell_surface *shell_surface,
                               QtWaylandClient::QWaylandWindow *window,
                               const QSize &size,
                               EmbeddedShellTypes::Anchor anchor,
@@ -32,12 +33,14 @@ private:
   EmbeddedShellTypes::Anchor m_anchor;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
+  bool m_visible = false;
   QSize m_pendingSize = {0, 0};
   QPointer<EmbeddedShellSurfaceView> m_selectedView;
   EmbeddedShellSurface *q_ptr = nullptr;
 
 protected:
   void embedded_shell_surface_configure(int32_t width, int32_t height) override;
+  void embedded_shell_surface_visible_changed(int32_t visible) override;
 };
 
 class EmbeddedShellSurfaceViewPrivate : public QObject,

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "embeddedshellsurfaceview.h"
+#include "embeddedshellsurfaceview_p.h"
+
+#include <QDebug>
+
+EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
+                                                                 ::surface_view *view,
+                                                                 EmbeddedShellSurface *surf)
+    : QObject(surf)
+    , QtWayland::surface_view(view)
+    , q_ptr(q)
+    , m_sortIndex(0)
+    , m_selected(false)
+{
+}
+
+EmbeddedShellSurfaceViewPrivate::~EmbeddedShellSurfaceViewPrivate()
+{
+  destroy();
+}
+
+EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedShellSurfaceView *q)
+{
+  return q->d_func();
+}
+
+void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
+{
+  qDebug() << __PRETTY_FUNCTION__;
+  Q_Q(EmbeddedShellSurfaceView);
+  q->setSelected(true);
+}
+
+EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
+                                                   EmbeddedShellSurface *surf)
+    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf))
+{
+}
+
+QString EmbeddedShellSurfaceView::appLabel() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_appLabel;
+}
+
+void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_appLabel == appLabel)
+    return;
+  d->m_appLabel = appLabel;
+  d->set_app_label(appLabel);
+  Q_EMIT appLabelChanged(appLabel);
+}
+
+QString EmbeddedShellSurfaceView::appIcon() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_appIcon;
+}
+
+void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_appIcon == appIcon)
+    return;
+  d->m_appIcon = appIcon;
+  d->set_app_icon(appIcon);
+  Q_EMIT appIconChanged(appIcon);
+}
+
+QString EmbeddedShellSurfaceView::label() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_label;
+}
+
+void EmbeddedShellSurfaceView::setLabel(const QString &label)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_label == label)
+    return;
+  d->m_label = label;
+  d->set_label(label);
+  Q_EMIT labelChanged(label);
+}
+
+QString EmbeddedShellSurfaceView::icon() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_icon;
+}
+
+void EmbeddedShellSurfaceView::setIcon(const QString &icon)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_icon == icon)
+    return;
+  d->m_icon = icon;
+  d->set_icon(icon);
+  Q_EMIT iconChanged(icon);
+}
+
+unsigned int EmbeddedShellSurfaceView::sortIndex() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_sortIndex;
+}
+
+void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_sortIndex == sortIndex)
+    return;
+  d->m_sortIndex = sortIndex;
+  d->set_sort_index(sortIndex);
+  Q_EMIT sortIndexChanged(sortIndex);
+}
+
+bool EmbeddedShellSurfaceView::selected() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_selected;
+}
+
+void EmbeddedShellSurfaceView::setSelected(bool selected)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_selected == selected)
+    return;
+  d->m_selected = selected;
+  Q_EMIT selectedChanged(selected);
+}

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef EMBEDDEDSHELLSURFACEVIEW_H
+#define EMBEDDEDSHELLSURFACEVIEW_H
+
+#include "embeddedshellsurface.h"
+
+#include <QObject>
+
+class EmbeddedShellSurfaceViewPrivate;
+
+struct surface_view;
+
+class EmbeddedShellSurfaceView : public QObject
+{
+  Q_OBJECT
+  Q_DECLARE_PRIVATE(EmbeddedShellSurfaceView)
+  QScopedPointer<EmbeddedShellSurfaceViewPrivate> d_ptr;
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
+  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
+  Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged)
+
+public:
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+  Q_SIGNAL void appLabelChanged(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+  Q_SIGNAL void appIconChanged(const QString &appIcon);
+
+  QString label() const;
+  void setLabel(const QString &label);
+  Q_SIGNAL void labelChanged(const QString &label);
+
+  QString icon() const;
+  void setIcon(const QString &icon);
+  Q_SIGNAL void iconChanged(const QString &icon);
+
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int sortIndex);
+  Q_SIGNAL void sortIndexChanged(unsigned int sortIndex);
+
+  bool selected() const;
+  void setSelected(bool selected);
+  Q_SIGNAL void selectedChanged(bool selected);
+
+private:
+  friend class EmbeddedShellSurface;
+  EmbeddedShellSurfaceView(struct ::surface_view *view,
+                           EmbeddedShellSurface *surf);
+};
+
+#endif // EMBEDDEDSHELLSURFACEVIEW_H

--- a/embeddedplatform/embeddedshellsurfaceview_p.h
+++ b/embeddedplatform/embeddedshellsurfaceview_p.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef EMBEDDEDSHELLSURFACEVIEW_P_H
+#define EMBEDDEDSHELLSURFACEVIEW_P_H
+
+#include "embeddedshellsurfaceview.h"
+#include "qwayland-embedded-shell.h"
+
+class EmbeddedShellSurfaceViewPrivate : public QObject,
+                                        public QtWayland::surface_view
+{
+  Q_DECLARE_PUBLIC(EmbeddedShellSurfaceView)
+  Q_OBJECT
+
+public:
+  EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
+                                  ::surface_view *view,
+                                  EmbeddedShellSurface *surf);
+
+  ~EmbeddedShellSurfaceViewPrivate() override;
+
+  static EmbeddedShellSurfaceViewPrivate *get(EmbeddedShellSurfaceView *q);
+
+  void surface_view_selected() override;
+
+  EmbeddedShellSurfaceView *q_ptr = nullptr;
+
+  QString m_appId;
+  QString m_appLabel;
+  QString m_appIcon;
+  QString m_label;
+  QString m_icon;
+  uint32_t m_sortIndex;
+  bool m_selected;
+};
+#endif // EMBEDDEDSHELLSURFACEVIEW_P_H

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -50,6 +50,10 @@
 			<arg name="height" type="int" />
 		</event>
 
+                <event name="visible_changed">
+		        <arg name="visible" type="int" />
+		</event>
+
 		<request name="view_create">
 			<description summary="create an embedded shell surface_view">
 				Creates an Embedded Shell Surface.

--- a/quickembeddedshellwindow/CMakeLists.txt
+++ b/quickembeddedshellwindow/CMakeLists.txt
@@ -11,6 +11,7 @@ qt_add_qml_module(${PROJECT_NAME}
     SOURCES
         quickembeddedshellwindow.cpp quickembeddedshellwindow.h
         quickembeddedshellview.cpp quickembeddedshellview.h
+        quickembeddedshellsurface.cpp quickembeddedshellsurface.h
         quickembeddedshellwindow_global.h
         quickembeddedshelltypes.h
         waylandinputregion.cpp waylandinputregion.h

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -18,6 +18,7 @@ QuickEmbeddedShellSurface::QuickEmbeddedShellSurface(QObject *parent)
     , m_margin(-1)
     , m_sortIndex(0)
     , m_componentComplete(false)
+    , m_visible(false)
 {
 }
 
@@ -66,6 +67,13 @@ void QuickEmbeddedShellSurface::componentComplete()
     m_surface->sendAppId(m_appId);
     m_surface->sendAppLabel(m_appLabel);
     m_surface->sendAppIcon(m_appIcon);
+
+    connect(m_surface, &EmbeddedShellSurface::visibleChanged, this, &QuickEmbeddedShellSurface::visibleChanged);
+
+    if (m_surface->getVisible())
+    {
+      emit visibleChanged(true);
+    }
 
     m_componentComplete = true;
     Q_EMIT completedChanged(m_componentComplete);
@@ -264,6 +272,11 @@ void QuickEmbeddedShellSurface::setAppIcon(const QString &appIcon)
 bool QuickEmbeddedShellSurface::completed() const
 {
   return m_componentComplete;
+}
+
+bool QuickEmbeddedShellSurface::visible() const
+{
+  return m_surface && m_surface->getVisible();
 }
 
 EmbeddedShellSurfaceView *QuickEmbeddedShellSurface::createView(const QString &appId,

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -57,11 +57,15 @@ void QuickEmbeddedShellSurface::componentComplete()
   else
   {
     m_surface = surface;
-    m_surface->sendAnchor(m_anchor);
-    m_surface->sendMargin(m_margin);
     if (m_size.isValid()) {
       m_surface->sendSize(m_size);
     }
+    m_surface->sendAnchor(m_anchor);
+    m_surface->sendMargin(m_margin);
+    m_surface->sendSortIndex(m_sortIndex);
+    m_surface->sendAppId(m_appId);
+    m_surface->sendAppLabel(m_appLabel);
+    m_surface->sendAppIcon(m_appIcon);
 
     m_componentComplete = true;
     Q_EMIT completedChanged(m_componentComplete);
@@ -91,8 +95,9 @@ EmbeddedShellTypes::Anchor QuickEmbeddedShellSurface::anchor() const
 
 void QuickEmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
 {
-  if (m_anchor == newAnchor)
+  if (m_anchor == newAnchor) {
     return;
+  }
 
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
 
@@ -157,8 +162,9 @@ int QuickEmbeddedShellSurface::margin() const
 
 void QuickEmbeddedShellSurface::setMargin(int newMargin)
 {
-  if (m_margin == newMargin)
+  if (m_margin == newMargin) {
     return;
+  }
 
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << newMargin;
 
@@ -177,8 +183,9 @@ unsigned int QuickEmbeddedShellSurface::sortIndex() const
 
 void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
 {
-  if (m_sortIndex == sortIndex)
+  if (m_sortIndex == sortIndex) {
     return;
+  }
 
   qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
 
@@ -187,6 +194,70 @@ void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
 
   if (m_componentComplete && m_surface) {
     m_surface->sendSortIndex(m_sortIndex);
+  }
+}
+
+QString QuickEmbeddedShellSurface::appId() const
+{
+  return m_appId;
+}
+
+void QuickEmbeddedShellSurface::setAppId(const QString &appId)
+{
+  if (m_componentComplete) {
+    qCWarning(quickShell) << __PRETTY_FUNCTION__ << "AppId cannot be changed after the component has been completed!";
+    return;
+  }
+
+  if (m_appId == appId) {
+    return;
+  }
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId;
+
+  m_appId = appId;
+  Q_EMIT appIdChanged(appId);
+}
+
+QString QuickEmbeddedShellSurface::appLabel() const
+{
+  return m_appLabel;
+}
+
+void QuickEmbeddedShellSurface::setAppLabel(const QString &appLabel)
+{
+  if (m_appLabel == appLabel) {
+    return;
+  }
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appLabel;
+
+  m_appLabel = appLabel;
+  Q_EMIT appLabelChanged(appLabel);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendAppLabel(m_appLabel);
+  }
+}
+
+QString QuickEmbeddedShellSurface::appIcon() const
+{
+  return m_appIcon;
+}
+
+void QuickEmbeddedShellSurface::setAppIcon(const QString &appIcon)
+{
+  if (m_appIcon == appIcon) {
+    return;
+  }
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appIcon;
+
+  m_appIcon = appIcon;
+  Q_EMIT appIconChanged(appIcon);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendAppIcon(m_appIcon);
   }
 }
 

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -1,0 +1,228 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#include "quickembeddedshellsurface.h"
+#include "embeddedshellsurface.h"
+
+#include <QQmlApplicationEngine>
+
+#include <memory>
+
+Q_LOGGING_CATEGORY(quickShell, "embeddedshell.quick")
+
+QuickEmbeddedShellSurface::QuickEmbeddedShellSurface(QObject *parent)
+    : QObject(parent)
+    , m_window(nullptr)
+    , m_size(QSize{0, 0})
+    , m_anchor(EmbeddedShellTypes::Anchor::Undefined)
+    , m_surface(nullptr)
+    , m_margin(-1)
+    , m_sortIndex(0)
+    , m_componentComplete(false)
+{
+}
+
+void QuickEmbeddedShellSurface::classBegin()
+{
+}
+
+void QuickEmbeddedShellSurface::componentComplete()
+{
+  if (!m_window) {
+    qCCritical(quickShell) << __PRETTY_FUNCTION__ << "called without a window set; aborting component completion.";
+    return;
+  }
+
+  auto surface = EmbeddedPlatform::shellSurfaceForWindow(m_window);
+
+  if (!surface) {
+    auto engine = dynamic_cast<QQmlApplicationEngine *>(qmlEngine(m_window));
+    // If the surface is null, the component creation of the window has not yet been completed.
+
+    if (engine) {
+      // When the QML engine is of type QQmlApplicationEngine, we can deduce component completion via
+      // QQmlApplicationEngine::objectCreated.
+      auto connection = std::make_shared<QMetaObject::Connection>();
+      *connection = connect(engine, &QQmlApplicationEngine::objectCreated, this, [this, connection](QObject *object) {
+        if (object == m_window) {
+          disconnect(*connection);
+          componentComplete();
+        }
+      });
+    } else {
+      // If it isn't of type QQmlApplicationEngine, we use a queued connection as a fall back fall back since
+      // component creation usually is resolved one event loop cycle later.
+      QMetaObject::invokeMethod(this, &QuickEmbeddedShellSurface::componentComplete, Qt::QueuedConnection);
+    }
+  }
+  else
+  {
+    m_surface = surface;
+    m_surface->sendAnchor(m_anchor);
+    m_surface->sendMargin(m_margin);
+    if (m_size.isValid()) {
+      m_surface->sendSize(m_size);
+    }
+
+    m_componentComplete = true;
+    Q_EMIT completedChanged(m_componentComplete);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_surface << m_anchor << m_margin << m_size << m_sortIndex;
+  }
+}
+
+QWindow *QuickEmbeddedShellSurface::window() const
+{
+  return m_window;
+}
+
+void QuickEmbeddedShellSurface::setWindow(QWindow *window)
+{
+  if (!m_window && window) {
+    m_window = window;
+    Q_EMIT windowChanged(window);
+  } else {
+    qCWarning(quickShell) << "Invalid window assignment from" << m_window << "to" << window << "!";
+  }
+}
+
+EmbeddedShellTypes::Anchor QuickEmbeddedShellSurface::anchor() const
+{
+  return m_anchor;
+}
+
+void QuickEmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
+{
+  if (m_anchor == newAnchor)
+    return;
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
+
+  m_anchor = newAnchor;
+  Q_EMIT anchorChanged(newAnchor);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendAnchor(m_anchor);
+  }
+}
+
+
+
+int QuickEmbeddedShellSurface::implicitWidth() const
+{
+  return m_size.width();
+}
+
+void QuickEmbeddedShellSurface::setImplicitWidth(int implicitWidth)
+{
+  const QSize newSize{implicitWidth, m_size.height()};
+  if (m_size == newSize) {
+    return;
+  }
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitWidth;
+
+  m_size = newSize;
+  Q_EMIT implicitWidthChanged(implicitWidth);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendSize(m_size);
+  }
+}
+
+int QuickEmbeddedShellSurface::implicitHeight() const
+{
+  return m_size.height();
+}
+
+void QuickEmbeddedShellSurface::setImplicitHeight(int implicitHeight)
+{
+  const QSize newSize{m_size.width(), implicitHeight};
+  if (m_size == newSize) {
+    return;
+  }
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitHeight;
+
+  m_size = newSize;
+  Q_EMIT implicitHeightChanged(implicitHeight);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendSize(m_size);
+  }
+}
+
+int QuickEmbeddedShellSurface::margin() const
+{
+  return m_margin;
+}
+
+void QuickEmbeddedShellSurface::setMargin(int newMargin)
+{
+  if (m_margin == newMargin)
+    return;
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << newMargin;
+
+  m_margin = newMargin;
+  Q_EMIT marginChanged(newMargin);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendMargin(m_margin);
+  }
+}
+
+unsigned int QuickEmbeddedShellSurface::sortIndex() const
+{
+  return m_sortIndex;
+}
+
+void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
+{
+  if (m_sortIndex == sortIndex)
+    return;
+
+  qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
+
+  m_sortIndex = sortIndex;
+  Q_EMIT sortIndexChanged(sortIndex);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->sendSortIndex(m_sortIndex);
+  }
+}
+
+bool QuickEmbeddedShellSurface::completed() const
+{
+  return m_componentComplete;
+}
+
+EmbeddedShellSurfaceView *QuickEmbeddedShellSurface::createView(const QString &appId,
+                                                                const QString &appLabel,
+                                                                const QString &label,
+                                                                unsigned int sort_index)
+{
+  if (m_surface) {
+    auto view = m_surface->createView(appId, appLabel, label, sort_index);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
+    return view;
+  } else {
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    return nullptr;
+  }
+}
+
+EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& appId,
+                                                                const QString& appLabel,
+                                                                const QString& appIcon,
+                                                                const QString& label,
+                                                                const QString& icon,
+                                                                uint32_t sort_index)
+{
+  if (m_surface) {
+    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
+    return view;
+  } else {
+    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    return nullptr;
+  }
+}

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -5,12 +5,12 @@
 
 #include "embeddedplatform.h"
 #include "quickembeddedshellwindow_global.h"
+#include "embeddedshellsurfaceview.h"
 
 #include <QQmlParserStatus>
 #include <QObject>
 #include <QtQml>
 
-class EmbeddedShellSurfaceView;
 class EmbeddedShellSurface;
 
 Q_DECLARE_LOGGING_CATEGORY(quickShell)

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -37,6 +37,7 @@ public:
   Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
   Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
+  Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
 
   void classBegin() override;
   void componentComplete() override;
@@ -69,6 +70,7 @@ public:
   void setAppIcon(const QString &appIcon);
 
   bool completed() const;
+  bool visible() const;
 
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
                                                    const QString &appLabel,
@@ -93,6 +95,7 @@ signals:
   void appLabelChanged(const QString &appLabel);
   void appIconChanged(const QString &appIcon);
   void completedChanged(bool completed);
+  void visibleChanged(bool visible);
 
 private:
   QWindow *m_window;
@@ -105,6 +108,7 @@ private:
   QString m_appLabel;
   QString m_appIcon;
   bool m_componentComplete;
+  bool m_visible;
 };
 
 #endif // QUICKEMBEDDEDSHELLSURFACE_H

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -33,6 +33,9 @@ public:
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
 
   void classBegin() override;
@@ -56,6 +59,15 @@ public:
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
 
+  QString appId() const;
+  void setAppId(const QString &appId);
+
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+
   bool completed() const;
 
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
@@ -77,6 +89,9 @@ signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sortIndex);
+  void appIdChanged(const QString &appId);
+  void appLabelChanged(const QString &appLabel);
+  void appIconChanged(const QString &appIcon);
   void completedChanged(bool completed);
 
 private:
@@ -86,6 +101,9 @@ private:
   EmbeddedShellSurface *m_surface;
   int m_margin;
   unsigned int m_sortIndex;
+  QString m_appId;
+  QString m_appLabel;
+  QString m_appIcon;
   bool m_componentComplete;
 };
 

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#ifndef QUICKEMBEDDEDSHELLSURFACE_H
+#define QUICKEMBEDDEDSHELLSURFACE_H
+
+#include "embeddedplatform.h"
+#include "quickembeddedshellwindow_global.h"
+
+#include <QQmlParserStatus>
+#include <QObject>
+#include <QtQml>
+
+class EmbeddedShellSurfaceView;
+class EmbeddedShellSurface;
+
+Q_DECLARE_LOGGING_CATEGORY(quickShell)
+
+class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellSurface
+    : public QObject,
+      public QQmlParserStatus
+{
+  Q_OBJECT
+  QML_NAMED_ELEMENT(Surface)
+
+public:
+  Q_INTERFACES(QQmlParserStatus)
+
+  QuickEmbeddedShellSurface(QObject *parent = nullptr);
+
+  Q_PROPERTY(QWindow *window READ window WRITE setWindow NOTIFY windowChanged)
+  Q_PROPERTY(int implicitWidth READ implicitWidth WRITE setImplicitWidth NOTIFY implicitWidthChanged)
+  Q_PROPERTY(int implicitHeight READ implicitHeight WRITE setImplicitHeight NOTIFY implicitHeightChanged)
+  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
+  Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
+
+  void classBegin() override;
+  void componentComplete() override;
+
+  EmbeddedShellTypes::Anchor anchor() const;
+  void setAnchor(EmbeddedShellTypes::Anchor newAnchor);
+
+  QWindow *window() const;
+  void setWindow(QWindow *window);
+
+  int implicitWidth() const;
+  void setImplicitWidth(int implicitWidth);
+
+  int implicitHeight() const;
+  void setImplicitHeight(int implicitHeight);
+
+  int margin() const;
+  void setMargin(int newMargin);
+
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int sortIndex);
+
+  bool completed() const;
+
+  Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
+                                                   const QString &appLabel,
+                                                   const QString &label,
+                                                   unsigned int sort_index);
+
+  Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
+                                                   const QString &appLabel,
+                                                   const QString &appIcon,
+                                                   const QString &label,
+                                                   const QString &icon,
+                                                   uint32_t sort_index);
+
+signals:
+  void windowChanged(QWindow *window);
+  void implicitWidthChanged(int implicitWidth);
+  void implicitHeightChanged(int implicitHeight);
+  void anchorChanged(EmbeddedShellTypes::Anchor anchor);
+  void marginChanged(int margin);
+  void sortIndexChanged(unsigned int sortIndex);
+  void completedChanged(bool completed);
+
+private:
+  QWindow *m_window;
+  QSize m_size;
+  EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
+  EmbeddedShellSurface *m_surface;
+  int m_margin;
+  unsigned int m_sortIndex;
+  bool m_componentComplete;
+};
+
+#endif // QUICKEMBEDDEDSHELLSURFACE_H

--- a/quickembeddedshellwindow/quickembeddedshelltypes.h
+++ b/quickembeddedshellwindow/quickembeddedshelltypes.h
@@ -5,6 +5,7 @@
 
 #include "embeddedplatform.h"
 #include "embeddedshellsurface.h"
+#include "embeddedshellsurfaceview.h"
 #include "embeddedshelltypes.h"
 
 #include <QtQml>

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -3,7 +3,7 @@
 
 QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
     : QQuickItem(parent)
-    , m_embeddedShellWindow(nullptr)
+    , m_surface(nullptr)
     , m_isCurrentView(false)
     , m_sortIndex(0)
     , m_completed(false)
@@ -12,27 +12,27 @@ QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
 
 void QuickEmbeddedShellView::componentComplete()
 {
-  Q_ASSERT(m_embeddedShellWindow);
+  Q_ASSERT(m_surface);
 
-  if (m_embeddedShellWindow->completed()) {
+  if (m_surface->completed()) {
     createView();
   } else {
-    connect(m_embeddedShellWindow, &QuickEmbeddedShellWindow::completedChanged, this, &QuickEmbeddedShellView::createView, Qt::SingleShotConnection);
+    connect(m_surface, &QuickEmbeddedShellSurface::completedChanged, this, &QuickEmbeddedShellView::createView, Qt::SingleShotConnection);
   }
 
   QQuickItem::componentComplete();
 }
 
-QuickEmbeddedShellWindow *QuickEmbeddedShellView::embeddedShellWindow() const
+QuickEmbeddedShellSurface *QuickEmbeddedShellView::surface() const
 {
-  return m_embeddedShellWindow;
+  return m_surface;
 }
 
-void QuickEmbeddedShellView::setEmbeddedShellWindow(QuickEmbeddedShellWindow *embeddedShellWindow)
+void QuickEmbeddedShellView::setSurface(QuickEmbeddedShellSurface *surface)
 {
-  if (!m_embeddedShellWindow && embeddedShellWindow) {
-    m_embeddedShellWindow = embeddedShellWindow;
-    Q_EMIT embeddedShellWindowChanged(embeddedShellWindow);
+  if (!m_surface && surface) {
+    m_surface = surface;
+    Q_EMIT surfaceChanged(surface);
   }
 }
 
@@ -51,7 +51,7 @@ void QuickEmbeddedShellView::setIsCurrentView(bool isCurrentView)
 
 void QuickEmbeddedShellView::createView()
 {
-  auto view = m_embeddedShellWindow->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex);
+  auto view = m_surface->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex);
   Q_ASSERT(view);
 
   connect(view, &EmbeddedShellSurfaceView::selected, this, [view, this]() {

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -4,7 +4,7 @@
 QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
     : QQuickItem(parent)
     , m_surface(nullptr)
-    , m_isCurrentView(false)
+    , m_selected(false)
     , m_sortIndex(0)
     , m_completed(false)
 {
@@ -36,16 +36,16 @@ void QuickEmbeddedShellView::setSurface(QuickEmbeddedShellSurface *surface)
   }
 }
 
-bool QuickEmbeddedShellView::isCurrentView() const
+bool QuickEmbeddedShellView::selected() const
 {
-  return m_isCurrentView;
+  return m_selected;
 }
 
-void QuickEmbeddedShellView::setIsCurrentView(bool isCurrentView)
+void QuickEmbeddedShellView::setSelected(bool selected)
 {
-  if (m_isCurrentView != isCurrentView) {
-    m_isCurrentView = isCurrentView;
-    Q_EMIT isCurrentViewChanged(isCurrentView);
+  if (m_selected != selected) {
+    m_selected = selected;
+    Q_EMIT selectedChanged(selected);
   }
 }
 
@@ -54,12 +54,7 @@ void QuickEmbeddedShellView::createView()
   auto view = m_surface->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex);
   Q_ASSERT(view);
 
-  connect(view, &EmbeddedShellSurfaceView::selected, this, [view, this]() {
-    setIsCurrentView(true);
-  });
-  connect(view, &EmbeddedShellSurfaceView::deselected, this, [view, this]() {
-    setIsCurrentView(false);
-  });
+  connect(view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::setSelected);
   connect(this, &QuickEmbeddedShellView::appLabelChanged, view, &EmbeddedShellSurfaceView::setAppLabel);
   connect(this, &QuickEmbeddedShellView::appIconChanged, view, &EmbeddedShellSurfaceView::setAppIcon);
   connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -14,7 +14,7 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
   QML_NAMED_ELEMENT(View)
 
   Q_PROPERTY(QuickEmbeddedShellSurface *surface READ surface WRITE setSurface NOTIFY surfaceChanged)
-  Q_PROPERTY(bool isCurrentView READ isCurrentView NOTIFY isCurrentViewChanged)
+  Q_PROPERTY(bool selected READ selected NOTIFY selectedChanged)
 
   Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
   Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
@@ -31,7 +31,7 @@ public:
   QuickEmbeddedShellSurface *surface() const;
   void setSurface(QuickEmbeddedShellSurface *surface);
 
-  bool isCurrentView() const;
+  bool selected() const;
 
   QString appId() const;
   void setAppId(const QString &appId);
@@ -53,7 +53,7 @@ public:
 
 signals:
   void surfaceChanged(QuickEmbeddedShellSurface *surface);
-  void isCurrentViewChanged(bool isCurrentView);
+  void selectedChanged(bool selected);
   void appIdChanged(const QString &appId);
   void appLabelChanged(const QString &appLabel);
   void appIconChanged(const QString &appIcon);
@@ -62,11 +62,11 @@ signals:
   void sortIndexChanged(quint32 sortIndex);
 
 private:
-  void setIsCurrentView(bool isCurrentView);
+  void setSelected(bool selected);
   void createView();
 
   QuickEmbeddedShellSurface *m_surface;
-  bool m_isCurrentView;
+  bool m_selected;
 
   QString m_appId;
   QString m_appLabel;

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -3,7 +3,7 @@
 #ifndef QUICKEMBEDDEDSHELLVIEW_H
 #define QUICKEMBEDDEDSHELLVIEW_H
 
-#include "quickembeddedshellwindow.h"
+#include "quickembeddedshellsurface.h"
 #include "quickembeddedshellwindow_global.h"
 
 #include <QQuickItem>
@@ -13,7 +13,7 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
   Q_OBJECT
   QML_NAMED_ELEMENT(View)
 
-  Q_PROPERTY(QuickEmbeddedShellWindow *embeddedShellWindow READ embeddedShellWindow WRITE setEmbeddedShellWindow NOTIFY embeddedShellWindowChanged)
+  Q_PROPERTY(QuickEmbeddedShellSurface *surface READ surface WRITE setSurface NOTIFY surfaceChanged)
   Q_PROPERTY(bool isCurrentView READ isCurrentView NOTIFY isCurrentViewChanged)
 
   Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
@@ -28,8 +28,8 @@ public:
 
   void componentComplete() override;
 
-  QuickEmbeddedShellWindow *embeddedShellWindow() const;
-  void setEmbeddedShellWindow(QuickEmbeddedShellWindow *embeddedShellWindow);
+  QuickEmbeddedShellSurface *surface() const;
+  void setSurface(QuickEmbeddedShellSurface *surface);
 
   bool isCurrentView() const;
 
@@ -52,7 +52,7 @@ public:
   void setSortIndex(quint32 sortIndex);
 
 signals:
-  void embeddedShellWindowChanged(QuickEmbeddedShellWindow *embeddedShellWindow);
+  void surfaceChanged(QuickEmbeddedShellSurface *surface);
   void isCurrentViewChanged(bool isCurrentView);
   void appIdChanged(const QString &appId);
   void appLabelChanged(const QString &appLabel);
@@ -65,7 +65,7 @@ private:
   void setIsCurrentView(bool isCurrentView);
   void createView();
 
-  QuickEmbeddedShellWindow *m_embeddedShellWindow;
+  QuickEmbeddedShellSurface *m_surface;
   bool m_isCurrentView;
 
   QString m_appId;

--- a/quickembeddedshellwindow/quickembeddedshellwindow.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.cpp
@@ -3,155 +3,24 @@
 #include "quickembeddedshellwindow.h"
 #include "embeddedshellsurface.h"
 
-Q_LOGGING_CATEGORY(quickShell, "embeddedshell.quick")
-
 QuickEmbeddedShellWindow::QuickEmbeddedShellWindow(QWindow *parent)
     : QQuickWindow(parent)
-    , m_size(QSize{0, 0})
 {
-  qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }
 
 QuickEmbeddedShellWindow::~QuickEmbeddedShellWindow() {}
 
-EmbeddedShellTypes::Anchor QuickEmbeddedShellWindow::anchor() const
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor;
-  return m_anchor;
-}
-
-void QuickEmbeddedShellWindow::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
-  if (m_anchor == newAnchor)
-    return;
-  m_anchor = newAnchor;
-  emit anchorChanged(newAnchor);
-}
-
-EmbeddedShellSurfaceView *QuickEmbeddedShellWindow::createView(const QString &appId,
-                                                               const QString &appLabel,
-                                                               const QString &label,
-                                                               unsigned int sort_index)
-{
-  if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, label, sort_index);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
-    return view;
-  } else {
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
-    return nullptr;
-  }
-}
-
-EmbeddedShellSurfaceView* QuickEmbeddedShellWindow::createView(const QString& appId,
-                                                               const QString& appLabel,
-                                                               const QString& appIcon,
-                                                               const QString& label,
-                                                               const QString& icon,
-                                                               uint32_t sort_index)
-{
-  if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
-    return view;
-  } else {
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
-    return nullptr;
-  }
-}
-
 void QuickEmbeddedShellWindow::classBegin()
 {
-  qCDebug(quickShell) << __PRETTY_FUNCTION__;
 }
 
 void QuickEmbeddedShellWindow::componentComplete()
 {
-  m_surface = EmbeddedPlatform::shellSurfaceForWindow(this);
-
-  if (m_surface) {
-    m_surface->sendAnchor(m_anchor);
-    m_surface->sendMargin(m_margin);
-    if (m_size.isValid()) {
-      m_surface->sendSize(m_size);
-    }
-  }
-  m_componentComplete = true;
-  emit completedChanged(m_componentComplete);
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_surface;
+  m_surface.setWindow(this);
+  m_surface.componentComplete();
 }
 
-int QuickEmbeddedShellWindow::implicitWidth() const
+QuickEmbeddedShellSurface *QuickEmbeddedShellWindow::surface()
 {
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.width();
-  return m_size.width();
-}
-
-void QuickEmbeddedShellWindow::setImplicitWidth(int implicitWidth)
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitWidth;
-  const QSize newSize{implicitWidth, m_size.height()};
-  if (m_size == newSize) {
-    return;
-  }
-  m_size = newSize;
-  Q_EMIT implicitWidthChanged(implicitWidth);
-  if (m_componentComplete && m_surface) {
-    m_surface->sendSize(m_size);
-  }
-}
-
-int QuickEmbeddedShellWindow::implicitHeight() const
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_size.height();
-  return m_size.height();
-}
-
-void QuickEmbeddedShellWindow::setImplicitHeight(int implicitHeight)
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitHeight;
-  const QSize newSize{m_size.width(), implicitHeight};
-  if (m_size == newSize) {
-    return;
-  }
-  m_size = newSize;
-  Q_EMIT implicitHeightChanged(implicitHeight);
-  if (m_componentComplete && m_surface) {
-    m_surface->sendSize(m_size);
-  }
-}
-
-int QuickEmbeddedShellWindow::margin() const
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_margin;
-  return m_margin;
-}
-
-void QuickEmbeddedShellWindow::setMargin(int newMargin)
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << newMargin;
-  if (m_margin == newMargin)
-    return;
-  m_margin = newMargin;
-  emit marginChanged(newMargin);
-}
-
-unsigned int QuickEmbeddedShellWindow::sortIndex() const
-{
-  return m_sortIndex;
-}
-
-void QuickEmbeddedShellWindow::setSortIndex(unsigned int sortIndex)
-{
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
-  if (m_sortIndex == sortIndex)
-    return;
-  m_sortIndex = sortIndex;
-  emit sortIndexChanged(sortIndex);
-}
-
-bool QuickEmbeddedShellWindow::completed() const
-{
-  return m_componentComplete;
+  return &m_surface;
 }

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -4,6 +4,7 @@
 #define QUICKEMBEDDEDSHELLWINDOW_H
 
 #include "embeddedplatform.h"
+#include "quickembeddedshellsurface.h"
 #include "quickembeddedshellwindow_global.h"
 
 #include <QLoggingCategory>
@@ -26,57 +27,17 @@ public:
 
   QuickEmbeddedShellWindow(QWindow *parent = nullptr);
   ~QuickEmbeddedShellWindow() override;
-  // Changes "size" but using "implicit" API style to be consistent with what QtQuick usually does for "wanted size".
-  Q_PROPERTY(int implicitWidth READ implicitWidth WRITE setImplicitWidth NOTIFY implicitWidthChanged)
-  Q_PROPERTY(int implicitHeight READ implicitHeight WRITE setImplicitHeight NOTIFY implicitHeightChanged)
-  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor
-                 NOTIFY anchorChanged)
-  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
-  Q_PROPERTY(
-      unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
 
-  EmbeddedShellTypes::Anchor anchor() const;
-  void setAnchor(EmbeddedShellTypes::Anchor newAnchor);
+  Q_PROPERTY(QuickEmbeddedShellSurface *surface READ surface CONSTANT)
 
   // QQmlParserStatus interface
   void classBegin() override;
   void componentComplete() override;
 
-  int implicitWidth() const;
-  void setImplicitWidth(int implicitWidth);
-  int implicitHeight() const;
-  void setImplicitHeight(int implicitHeight);
-  int margin() const;
-  void setMargin(int newMargin);
-  unsigned int sortIndex() const;
-  void setSortIndex(unsigned int sortIndex);
-  bool completed() const;
-
-public slots:
-  EmbeddedShellSurfaceView *createView(const QString &appId, const QString &appLabel, const QString &label, unsigned int sort_index);
-  EmbeddedShellSurfaceView *createView(const QString &appId,
-                                       const QString &appLabel,
-                                       const QString &appIcon,
-                                       const QString &label,
-                                       const QString &icon,
-                                       uint32_t sort_index);
-
-signals:
-  void implicitWidthChanged(int implicitWidth);
-  void implicitHeightChanged(int implicitHeight);
-  void anchorChanged(EmbeddedShellTypes::Anchor anchor);
-  void marginChanged(int margin);
-  void sortIndexChanged(unsigned int sortIndex);
-  void completedChanged(bool completed);
+  QuickEmbeddedShellSurface *surface();
 
 private:
-  QSize m_size;
-  EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
-  EmbeddedShellSurface *m_surface = nullptr;
-  int m_margin = -1;
-  unsigned int m_sortIndex = 0;
-  bool m_componentComplete = false;
+  QuickEmbeddedShellSurface m_surface;
 };
 
 #endif // QUICKEMBEDDEDSHELLWINDOW_H


### PR DESCRIPTION
Separating window and surface of QML interface to make it possible to use other QWindow based subclasses than QQuickWindow. The new QuickEmbeddedShellSurface class now contains all surface related properties while QuickEmbeddedShellWindow now only provides these properties implicitly via its new surface property.

This allows the usage of e.g. ApplicationWindow (from Qt Quick Controls) in the context of this compositor.