### PR TITLE
Adding customData property to surface and view

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,12 +95,12 @@ private slots:
     auto v1 = shellSurface->createView("View One", 3);
     auto v2 = shellSurface->createView("View Two", 2);
     auto v3 = shellSurface->createView("View Three", 1);
-    connect(v1, &EmbeddedShellSurfaceView::selected, this,
-            [=] { m_label->setText(v1->label()); });
-    connect(v2, &EmbeddedShellSurfaceView::selected, this,
-            [=] { m_label->setText(v2->label()); });
-    connect(v3, &EmbeddedShellSurfaceView::selected, this,
-            [=] { m_label->setText(v3->label()); });
+    connect(v1, &EmbeddedShellSurfaceView::selectedChanged, this,
+            [=](bool selected) { if (selected) m_label->setText(v1->label()); });
+    connect(v2, &EmbeddedShellSurfaceView::selectedChanged, this,
+            [=](bool selected) { if (selected) m_label->setText(v2->label()); });
+    connect(v3, &EmbeddedShellSurfaceView::selectedChanged, this,
+            [=](bool selected) { if (selected) m_label->setText(v3->label()); });
   }
 ```
 

--- a/README.md
+++ b/README.md
@@ -9,18 +9,13 @@ use of the [Qt Wayland module](https://doc.qt.io/qt-6/qtwaylandcompositor-index.
 [![build embedded compositor main](https://github.com/JUMO-GmbH-Co-KG/embedded-compositor/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/JUMO-GmbH-Co-KG/embedded-compositor/actions/workflows/main.yml)
 [![CodeFactor](https://www.codefactor.io/repository/github/jumo-gmbh-co-kg/embedded-compositor/badge)](https://www.codefactor.io/repository/github/jumo-gmbh-co-kg/embedded-compositor)
 
-### Qt5 on the **qt5** branch
-[![build embedded compositor qt5](https://github.com/JUMO-GmbH-Co-KG/embedded-compositor/actions/workflows/main.yml/badge.svg?branch=qt5)](https://github.com/JUMO-GmbH-Co-KG/embedded-compositor/actions/workflows/main.yml)
-[![CodeFactor](https://www.codefactor.io/repository/github/jumo-gmbh-co-kg/embedded-compositor/badge/qt5)](https://www.codefactor.io/repository/github/jumo-gmbh-co-kg/embedded-compositor/overview/qt5)
-
-
 ## Layouting and general behavior
 
 The compositor implements window management through its QML UI.
-It is based around a custom wayland shell interface that allows windows to specify
+It is based around a custom wayland shell interface and uses an interface called "embedded_shell_surface" that allows clients to specify:
 
-* an anchor representing a screen edge or the center area, and
-* a margin representing the width in pixels the window will reserve from that edge (if not placed in the center).
+* An anchor representing a screen edge or the center area.
+* A margin representing the width in pixels the window will reserve from that edge (if not placed in the center).
 
 After the reserved amount of screen space is subtracted from each edge, the remaining
 screen area is provided to applications displayed in the center area.
@@ -35,13 +30,15 @@ The compositor also implements a default task switcher.
 
 ## Virtual Surface Views
 
-We expect some applications having multiple views that should be listed in a task switcher independently, while belonging to the same logical window/wayland surface.
-For this purpose we devised an interface called "surface_view" that represents a view within the applications logic that can be switched to via tha global task switch UI.
+Besides the "embedded_shell_surface" interface, another interface "surface_view" is provided, which can be used to define a hierarchy of views that can be shown
+within a global task switcher UI. It allows to specify the following values:
 
-## Sorting Windows and Views
+* A name under which it shall be shown in the task switcher.
+* An optional icon identifier that the task switcher can use.
+* An optional parent view to define a view hierarchy.
+* An optional index that the task switcher can use to sort the views on the same level.
 
-It can be desirable to provide a predictable order of surfaces in the task switcher and for this purpose we added an index that surfaces and surface views can be sorted by.
-It is expected that clients read their sort index from configuration provided by the system integrator.
+Each surface_view belongs to one embedded_shell_surface. One embedded_shell_surface can have multiple surface_views.
 
 ## Wayland Protocol Extension
 
@@ -131,11 +128,10 @@ For convenience of QML applications, we also implement a QML interface to embedd
         MouseArea {
             anchors.fill: parent
             onClicked: {
-                var appId = "MyApp"
-                var appLabel = "My App"
-                var label = "My View"
+                var label = "My App"
+                var icon = "qrc:/Preview.jpg"
                 var sortIndex = 0
-                var view = myWindow.surface.createView(appId, appLabel, label, sortIndex);
+                var view = myWindow.surface.createView(label, icon, sortIndex);
                 view.selectedChanged.connect(function(){ if (view.selected) console.log("view", view.label, "was selected"); })
             }
         }
@@ -179,9 +175,8 @@ A declarative QML interface to embedded_shell_surface_view is also available (se
         View {
             id: myView
             surface: myWindow.surface
-            appId: "MyApp"
-            appLabel: "My App"
-            label: "My View"
+            label: "My App"
+            icon: "qrc:/Preview.jpg"
             sortIndex: 0
             
             Text { text: myView.label }
@@ -231,7 +226,7 @@ The compositor implements a couple of DBus interfaces to provide system/window m
 * /taskswitcher (de.EmbeddedCompositor.taskswitcher) - allows the task switcher to be opened or closed from e.g. a menu button. Provides List of currently active views (/taskswitcher/views) and allows currently active view to be queried and set (taskswitcher/currentView). Views are identified by a GUID and the list of surfaces includes process id and view label for convenience.
   * properties
     * currentView (type:string, access:readwrite)
-    * views (type:a(ssu), access:read)
+    * views (type:a(ssssua{sv}), access:read)
       * annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;" 
 * /globaloverlay (de.EmbeddedCompositor.globaloverlay) - displays a global overlay hiding all other UI elements for a boot or shutdown message.
 * /screen (de.EmbeddedCompositor.screen) - control screen orientation via the orientation property. allowed values: "0", "90", "180", "270"

--- a/dbus/de.EmbeddedCompositor.taskswitcher.xml
+++ b/dbus/de.EmbeddedCompositor.taskswitcher.xml
@@ -7,7 +7,7 @@
 <method name="Close"/>
 <property name="currentView" type="s" access="readwrite"/>
 <!-- app id, app label, app icon, view label, view icon, pid, sort index, properties -->
-<property name="views" type="a(ssssua{sv})"  access="read" >
+<property name="views" type="a(sbsssua{sv})"  access="read" >
     <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
 </property>
 </interface>

--- a/dbus/de.EmbeddedCompositor.taskswitcher.xml
+++ b/dbus/de.EmbeddedCompositor.taskswitcher.xml
@@ -7,7 +7,7 @@
 <method name="Close"/>
 <property name="currentView" type="s" access="readwrite"/>
 <!-- app id, app label, app icon, view label, view icon, pid, sort index, properties -->
-<property name="views" type="a(ssssssuua{sv})"  access="read" >
+<property name="views" type="a(ssssua{sv})"  access="read" >
     <annotation name="org.qtproject.QtDBus.QtTypeName" value="QList&lt;TaskSwitcherEntry&gt;"/>
 </property>
 </interface>

--- a/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
+++ b/dev-tools/testclients/widgetcenterclient/mainwindow.cpp
@@ -59,7 +59,7 @@ void MainWindow::initShell(EmbeddedShellSurface *shellSurface,
     qWarning() << "NO SHELL SURFACE!";
     return;
   }
-  shellSurface->sendAnchor(EmbeddedShellTypes::Anchor::Center);
+  shellSurface->setAnchor(EmbeddedShellTypes::Anchor::Center);
   auto v1 = shellSurface->createView("View One", "View One", 3);
   auto v2 = shellSurface->createView("View Two", "View Two", -2);
   auto v3 = shellSurface->createView("View Three", "View Three", 1);

--- a/dev-tools/testclients/widgetcenterclient/mainwindow.h
+++ b/dev-tools/testclients/widgetcenterclient/mainwindow.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef MAINWINDOW_H
-#define MAINWINDOW_H
+#pragma once
 
 #include <QMainWindow>
 
@@ -15,7 +14,7 @@ class MainWindow : public QMainWindow {
 public:
   MainWindow(QWidget *parent = nullptr);
   ~MainWindow() override;
-private slots:
+
+private:
   void initShell(EmbeddedShellSurface *, QWindow *);
 };
-#endif // MAINWINDOW_H

--- a/embedded-compositor/configurationhive.h
+++ b/embedded-compositor/configurationhive.h
@@ -1,5 +1,6 @@
-#ifndef CONFIGURATIONHIVE_H
-#define CONFIGURATIONHIVE_H
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#pragma once
 
 #include <QObject>
 #include <QQmlParserStatus>
@@ -13,5 +14,3 @@ public:
   void classBegin() override;
   void componentComplete() override;
 };
-
-#endif // CONFIGURATIONHIVE_H

--- a/embedded-compositor/dbus-selector.h
+++ b/embedded-compositor/dbus-selector.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#ifndef DBUSSELECTOR_H
-#define DBUSSELECTOR_H
+#pragma once
+
 #include <QDBusConnection>
 
 inline QDBusConnection getBus() {
@@ -18,4 +18,3 @@ constexpr QDBusConnection::BusType defaultBus =
 #else
     QDBusConnection::BusType::SessionBus;
 #endif
-#endif // DBUSSELECTOR_H

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -64,7 +64,7 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
             }
 
             entries.append({
-                view ? view->getUuid() : surface->getUuid(),
+                view ? view->uuid() : surface->uuid(),
                 appId,
                 appLabel,
                 appIcon,
@@ -126,9 +126,9 @@ void TaskSwitcherDBusInterface::setViewModel(QAbstractListModel *newViewModel)
                 &TaskSwitcherDBusInterface::viewsChanged);
     }
 
-    Q_EMIT viewModelChanged(m_viewModel);
+    emit viewModelChanged(m_viewModel);
 
-    Q_EMIT viewsChanged();
+    emit viewsChanged();
 }
 
 void TaskSwitcherDBusInterface::onViewsInserted(const QModelIndex &parent, int first, int last)

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -51,6 +51,7 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
             if (view) {
               entries.append({
                   view->uuid(),
+                  view->isPersistent(),
                   view->parentUuid(),
                   view->label(),
                   view->icon(),
@@ -67,7 +68,7 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
 QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument << entry.uuid << entry.parentUuid << entry.label << entry.icon << entry.sortIndex << entry.customData;
+    argument << entry.uuid << entry.isPresistent << entry.parentUuid << entry.label << entry.icon << entry.sortIndex << entry.customData;
     argument.endStructure();
     return argument;
 }
@@ -75,7 +76,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entr
 const QDBusArgument &operator>>(const QDBusArgument &argument, TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument >> entry.uuid >> entry.parentUuid >> entry.label >> entry.icon >> entry.sortIndex >> entry.customData;
+    argument >> entry.uuid >> entry.isPresistent >> entry.parentUuid >> entry.label >> entry.icon >> entry.sortIndex >> entry.customData;
     argument.endStructure();
     return argument;
 }

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -55,6 +55,7 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
                   view->label(),
                   view->icon(),
                   view->sortIndex(),
+                  view->customData()
               });
             }
         }
@@ -66,7 +67,7 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
 QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument << entry.uuid << entry.parentUuid << entry.label << entry.icon << entry.sortIndex;
+    argument << entry.uuid << entry.parentUuid << entry.label << entry.icon << entry.sortIndex << entry.customData;
     argument.endStructure();
     return argument;
 }
@@ -74,7 +75,7 @@ QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entr
 const QDBusArgument &operator>>(const QDBusArgument &argument, TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument >> entry.uuid >> entry.parentUuid >> entry.label >> entry.icon >> entry.sortIndex;
+    argument >> entry.uuid >> entry.parentUuid >> entry.label >> entry.icon >> entry.sortIndex >> entry.customData;
     argument.endStructure();
     return argument;
 }

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.cpp
@@ -28,9 +28,10 @@ QString TaskSwitcherDBusInterface::currentView() const
 
 void TaskSwitcherDBusInterface::setCurrentView(QString newCurrentView)
 {
-    qDebug() << "new current view " << newCurrentView;
     if (m_currentView == newCurrentView)
         return;
+
+    qDebug() << "new current view" << newCurrentView;
     m_currentView = newCurrentView;
     emit currentViewChanged(m_currentView);
 }
@@ -45,55 +46,35 @@ QList<TaskSwitcherEntry> TaskSwitcherDBusInterface::views() const
         for (auto i = 0; i < m_viewModel->rowCount(); i++) {
             const auto &data = m_viewModel->index(i).data().toMap();
 
-            auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>();
             auto *view = data.value(QStringLiteral("view")).value<EmbeddedShellSurfaceView *>();
 
-            QString appId = surface->appId();
-            if (view && !view->appId().isEmpty()) {
-                appId = view->appId();
+            if (view) {
+              entries.append({
+                  view->uuid(),
+                  view->parentUuid(),
+                  view->label(),
+                  view->icon(),
+                  view->sortIndex(),
+              });
             }
-
-            QString appLabel = surface->appLabel();
-            if (view && !view->appLabel().isEmpty()) {
-                appLabel = view->appLabel();
-            }
-
-            QString appIcon = surface->appIcon();
-            if (view && !view->appIcon().isEmpty()) {
-                appIcon = view->appIcon();
-            }
-
-            entries.append({
-                view ? view->uuid() : surface->uuid(),
-                appId,
-                appLabel,
-                appIcon,
-                view ? view->label() : QString(),
-                view ? view->icon() : QString(),
-                uint32_t(surface->getClientPid()),
-                view ? uint32_t(view->sortIndex()) : 0,
-                QVariantMap(), //args
-            });
         }
     }
 
     return entries;
 }
 
-QDBusArgument &operator<<(QDBusArgument &argument,
-                          const TaskSwitcherEntry &entry)
+QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument << entry.uuid << entry.appId << entry.appLabel << entry.appIcon << entry.label << entry.icon << entry.pid << entry.sortIndex << entry.args;
+    argument << entry.uuid << entry.parentUuid << entry.label << entry.icon << entry.sortIndex;
     argument.endStructure();
     return argument;
 }
 
-const QDBusArgument &operator>>(const QDBusArgument &argument,
-                                TaskSwitcherEntry &entry)
+const QDBusArgument &operator>>(const QDBusArgument &argument, TaskSwitcherEntry &entry)
 {
     argument.beginStructure();
-    argument >> entry.uuid >> entry.appId >> entry.appLabel >> entry.appIcon >> entry.label >> entry.icon >> entry.pid >> entry.sortIndex >> entry.args;
+    argument >> entry.uuid >> entry.parentUuid >> entry.label >> entry.icon >> entry.sortIndex;
     argument.endStructure();
     return argument;
 }
@@ -116,14 +97,9 @@ void TaskSwitcherDBusInterface::setViewModel(QAbstractListModel *newViewModel)
     m_viewModel = newViewModel;
 
     if (m_viewModel) {
-        connect(m_viewModel, &QAbstractItemModel::rowsInserted, this,
-                &TaskSwitcherDBusInterface::onViewsInserted);
-        connect(m_viewModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
-                &TaskSwitcherDBusInterface::onViewsAboutToBeRemoved);
-        connect(m_viewModel, &QAbstractItemModel::rowsInserted, this,
-                &TaskSwitcherDBusInterface::viewsChanged);
-        connect(m_viewModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
-                &TaskSwitcherDBusInterface::viewsChanged);
+        connect(m_viewModel, &QAbstractItemModel::rowsInserted, this, &TaskSwitcherDBusInterface::onViewsInserted);
+        connect(m_viewModel, &QAbstractItemModel::rowsInserted, this, &TaskSwitcherDBusInterface::viewsChanged);
+        connect(m_viewModel, &QAbstractItemModel::rowsRemoved, this, &TaskSwitcherDBusInterface::viewsChanged);
     }
 
     emit viewModelChanged(m_viewModel);
@@ -139,46 +115,10 @@ void TaskSwitcherDBusInterface::onViewsInserted(const QModelIndex &parent, int f
         const auto &data = m_viewModel->index(i).data().toMap();
 
         if (auto *view = data.value(QStringLiteral("view")).value<EmbeddedShellSurfaceView *>()) {
-            connect(view, &EmbeddedShellSurfaceView::appIdChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            connect(view, &EmbeddedShellSurfaceView::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            connect(view, &EmbeddedShellSurfaceView::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
             connect(view, &EmbeddedShellSurfaceView::labelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
             connect(view, &EmbeddedShellSurfaceView::iconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-        }
-
-        if (auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>()) {
-            if (m_ConnectedEmbeddedShellSurfaces[surface] == 0) {
-                connect(surface, &EmbeddedShellSurface::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-                connect(surface, &EmbeddedShellSurface::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            }
-
-            m_ConnectedEmbeddedShellSurfaces[surface]++;
-        }
-    }
-}
-
-void TaskSwitcherDBusInterface::onViewsAboutToBeRemoved(const QModelIndex &parent, int first, int last)
-{
-    Q_ASSERT(!parent.isValid());
-
-    for (int i = first; i <= last; ++i) {
-        const auto &data = m_viewModel->index(i).data().toMap();
-
-        if (auto *view = data.value(QStringLiteral("view")).value<EmbeddedShellSurfaceView *>()) {
-            disconnect(view, &EmbeddedShellSurfaceView::appIdChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            disconnect(view, &EmbeddedShellSurfaceView::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            disconnect(view, &EmbeddedShellSurfaceView::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            disconnect(view, &EmbeddedShellSurfaceView::labelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            disconnect(view, &EmbeddedShellSurfaceView::iconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-        }
-
-        if (auto *surface = data.value(QStringLiteral("surface")).value<EmbeddedShellSurface *>()) {
-          m_ConnectedEmbeddedShellSurfaces[surface]--;
-
-          if (m_ConnectedEmbeddedShellSurfaces[surface] == 0) {
-            disconnect(surface, &EmbeddedShellSurface::appLabelChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-            disconnect(surface, &EmbeddedShellSurface::appIconChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
-          }
+            connect(view, &EmbeddedShellSurfaceView::sortIndexChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
+            connect(view, &EmbeddedShellSurfaceView::customDataChanged, this, &TaskSwitcherDBusInterface::viewsChanged);
         }
     }
 }

--- a/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherDBusInterface.hpp
@@ -20,11 +20,9 @@ public:
     explicit TaskSwitcherDBusInterface(QObject *parent = nullptr);
     virtual ~TaskSwitcherDBusInterface() override = default;
 
-    Q_PROPERTY(QString currentView READ currentView WRITE setCurrentView NOTIFY
-                   currentViewChanged)
+    Q_PROPERTY(QString currentView READ currentView WRITE setCurrentView NOTIFY currentViewChanged)
     Q_PROPERTY(QList<TaskSwitcherEntry> views READ views NOTIFY viewsChanged)
-    Q_PROPERTY(QAbstractListModel *viewModel READ viewModel WRITE setViewModel
-                   NOTIFY viewModelChanged)
+    Q_PROPERTY(QAbstractListModel *viewModel READ viewModel WRITE setViewModel NOTIFY viewModelChanged)
 
     // DBus
     void Open();
@@ -48,9 +46,7 @@ signals:
 
 private:
     void onViewsInserted(const QModelIndex &parent, int first, int last);
-    void onViewsAboutToBeRemoved(const QModelIndex &parent, int first, int last);
 
     QString m_currentView;
     QAbstractListModel *m_viewModel = nullptr;
-    QHash<EmbeddedShellSurface *, int> m_ConnectedEmbeddedShellSurfaces;
 };

--- a/embedded-compositor/dbus/TaskSwitcherEntry.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherEntry.hpp
@@ -10,21 +10,14 @@
 struct TaskSwitcherEntry
 {
     QString uuid;
-    QString appId;
-    QString appLabel;
-    QString appIcon;
+    QString parentUuid;
     QString label;
     QString icon;
-    uint32_t pid;
     uint32_t sortIndex;
-    QVariantMap args; // for future extension
 };
 
 Q_DECLARE_METATYPE(TaskSwitcherEntry)
 Q_DECLARE_METATYPE(QList<TaskSwitcherEntry>)
 
-QDBusArgument &operator<<(QDBusArgument &argument,
-                          const TaskSwitcherEntry &entry);
-
-const QDBusArgument &operator>>(const QDBusArgument &argument,
-                                TaskSwitcherEntry &entry);
+QDBusArgument &operator<<(QDBusArgument &argument, const TaskSwitcherEntry &entry);
+const QDBusArgument &operator>>(const QDBusArgument &argument, TaskSwitcherEntry &entry);

--- a/embedded-compositor/dbus/TaskSwitcherEntry.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherEntry.hpp
@@ -10,10 +10,11 @@
 struct TaskSwitcherEntry
 {
     QString uuid;
+    bool isPresistent{false};
     QString parentUuid;
     QString label;
     QString icon;
-    uint32_t sortIndex;
+    uint32_t sortIndex{0};
     QVariantMap customData;
 };
 

--- a/embedded-compositor/dbus/TaskSwitcherEntry.hpp
+++ b/embedded-compositor/dbus/TaskSwitcherEntry.hpp
@@ -14,6 +14,7 @@ struct TaskSwitcherEntry
     QString label;
     QString icon;
     uint32_t sortIndex;
+    QVariantMap customData;
 };
 
 Q_DECLARE_METATYPE(TaskSwitcherEntry)

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -214,6 +214,7 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource
                                                               const QString &label,
                                                               const QString &icon,
                                                               unsigned int sort_index,
+                                                              const QString &persistentId,
                                                               wl_array *custom_data,
                                                               wl_resource *parent_view,
                                                               uint32_t id)
@@ -233,10 +234,11 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource
   }
 
   auto customDataVariant = array_to_variant_map(custom_data);
-  qCDebug(shellExt) << Q_FUNC_INFO << label << icon << id;
+  qCDebug(shellExt) << Q_FUNC_INFO << label << icon << sort_index << persistentId << custom_data;
   auto view = new EmbeddedShellSurfaceView(label,
                                            icon,
                                            sort_index,
+                                           persistentId,
                                            customDataVariant,
                                            resource->client(),
                                            parentView,
@@ -248,12 +250,15 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &label,
                                                    const QString &icon,
                                                    uint32_t sortIndex,
+                                                   const QString &persistentId,
                                                    const QVariantMap &customData,
                                                    wl_client *client,
                                                    EmbeddedShellSurfaceView *parentView,
                                                    int id,
                                                    int version)
     : QtWaylandServer::surface_view(client, id, version)
+    , m_isPersistent(!persistentId.isEmpty())
+    , m_uuid(m_isPersistent ? persistentId : QUuid::createUuid().toString(QUuid::WithoutBraces))
     , m_label(label)
     , m_icon(icon)
     , m_sortIndex(sortIndex)
@@ -289,7 +294,12 @@ QString EmbeddedShellSurfaceView::parentUuid() const
 
 QString EmbeddedShellSurfaceView::uuid() const
 {
-  return m_uuid.toString(QUuid::WithoutBraces);
+  return m_uuid;
+}
+
+bool EmbeddedShellSurfaceView::isPersistent() const
+{
+  return m_isPersistent;
 }
 
 void EmbeddedShellSurfaceView::select()

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -493,6 +493,13 @@ void EmbeddedShellSurfaceView::surface_view_set_custom_data(Resource *resource,
   setCustomData(array_to_variant(custom_data));
 }
 
+void EmbeddedShellSurfaceView::surface_view_select(Resource *resource)
+{
+  Q_UNUSED(resource)
+  emit aboutToBeSelected();
+  QtWaylandServer::surface_view::surface_view_select(resource);
+}
+
 void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource)
 {
   Q_UNUSED(resource)

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -59,33 +59,30 @@ void EmbeddedShellExtension::initialize()
   init(compositor->display(), 1);
 }
 
-void EmbeddedShellExtension::embedded_shell_surface_create(
-    Resource *resource,
-    wl_resource *wl_surface,
-    uint32_t id,
-    uint32_t anchor,
-    uint32_t margin,
-    unsigned int sort_index)
+void EmbeddedShellExtension::embedded_shell_surface_create(Resource *resource,
+                                                           wl_resource *wl_surface,
+                                                           uint32_t id,
+                                                           uint32_t anchor,
+                                                           uint32_t margin)
 {
-  qCDebug(shellExt) << Q_FUNC_INFO << id << "anchor" << anchor
-                    << "margin" << margin;
+  qCDebug(shellExt) << Q_FUNC_INFO << id << "anchor" << anchor << "margin" << margin;
   Q_UNUSED(resource)
 
   QWaylandSurface *surface = QWaylandSurface::fromResource(wl_surface);
 
-  QWaylandResource embeddedShellSurfaceResource(
-      wl_resource_create(resource->client(),
-                         &embedded_shell_surface_interface,
-                         wl_resource_get_version(resource->handle),
-                         id));
-  auto embeddedShellSurface = QtWayland::fromResource<EmbeddedShellSurface *>(
-      embeddedShellSurfaceResource.resource());
+  QWaylandResource embeddedShellSurfaceResource(wl_resource_create(resource->client(),
+                                                                   &embedded_shell_surface_interface,
+                                                                   wl_resource_get_version(resource->handle),
+                                                                   id));
+  auto embeddedShellSurface = QtWayland::fromResource<EmbeddedShellSurface *>(embeddedShellSurfaceResource.resource());
 
   if (!embeddedShellSurface) {
     qCDebug(shellExt) << "server received new surface" << surface << anchor;
-    embeddedShellSurface = new EmbeddedShellSurface(
-        this, surface, embeddedShellSurfaceResource,
-        static_cast<EmbeddedShellTypes::Anchor>(anchor), margin, sort_index);
+    embeddedShellSurface = new EmbeddedShellSurface(this,
+                                                    surface,
+                                                    embeddedShellSurfaceResource,
+                                                    static_cast<EmbeddedShellTypes::Anchor>(anchor),
+                                                    margin);
   } else {
     qCDebug(shellExt) << "server received already known surface" << surface
                       << embeddedShellSurface;
@@ -94,16 +91,18 @@ void EmbeddedShellExtension::embedded_shell_surface_create(
   emit surfaceAdded(embeddedShellSurface);
 }
 
-EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
+EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *extension,
                                            QWaylandSurface *surface,
                                            const QWaylandResource &resource,
                                            EmbeddedShellTypes::Anchor anchor,
-                                           uint32_t margin, uint32_t sort_index)
-    : QWaylandShellSurfaceTemplate<EmbeddedShellSurface>(this),
-      m_surface(surface), m_size(QSize{0, 0}), m_anchor(anchor), m_margin(margin),
-      m_sort_index(sort_index)
+                                           uint32_t margin)
+    : QWaylandShellSurfaceTemplate<EmbeddedShellSurface>(this)
+    , m_surface(surface)
+    , m_size(QSize{0, 0})
+    , m_anchor(anchor)
+    , m_margin(margin)
 {
-  Q_UNUSED(ext)
+  Q_UNUSED(extension)
   qCDebug(shellExt) << Q_FUNC_INFO << anchor
                     << wl_resource_get_id(resource.resource());
   init(resource.resource());
@@ -111,8 +110,7 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
   QWaylandCompositorExtension::initialize();
 }
 
-QWaylandQuickShellIntegration *
-EmbeddedShellSurface::createIntegration(QWaylandQuickShellSurfaceItem *item)
+QWaylandQuickShellIntegration *EmbeddedShellSurface::createIntegration(QWaylandQuickShellSurfaceItem *item)
 {
   qCDebug(shellExt) << Q_FUNC_INFO;
   return new QuickEmbeddedShellIntegration(item);
@@ -133,89 +131,14 @@ int EmbeddedShellSurface::margin()
   return m_margin;
 }
 
-void EmbeddedShellSurface::setSize(const QSize &size)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << m_size << "->" << size;
-    if (m_size != size) {
-        m_size = size;
-        emit sizeChanged(size);
-    }
-}
-
-QVariant EmbeddedShellSurface::customData() const
-{
-  return m_customData;
-}
-
-void EmbeddedShellSurface::setCustomData(const QVariant &customData)
-{
-  qCDebug(shellExt) << Q_FUNC_INFO << m_customData << "->" << customData;
-  if (m_customData != customData) {
-    m_customData = customData;
-    emit customDataChanged(customData);
-  }
-}
-
-void EmbeddedShellSurface::setMargin(int newMargin)
-{
-  qCDebug(shellExt) << Q_FUNC_INFO << newMargin;
-  m_margin = newMargin;
-  emit marginChanged(newMargin);
-}
-
-unsigned int EmbeddedShellSurface::sortIndex()
-{
-  return m_sort_index;
-}
-
-void EmbeddedShellSurface::setSortIndex(unsigned int sort_index)
-{
-  m_sort_index = sort_index;
-  emit sortIndexChanged(sort_index);
-}
-
-QString EmbeddedShellSurface::appId() const
-{
-  return m_appId;
-}
-
-void EmbeddedShellSurface::setAppId(const QString &appId)
-{
-  if (!m_appId.isEmpty()) {
-    return;
-  }
-  m_appId = appId;
-}
-
-QString EmbeddedShellSurface::appLabel() const
-{
-  return m_appLabel;
-}
-
-void EmbeddedShellSurface::setAppLabel(const QString &appLabel)
-{
-  if (m_appLabel != appLabel) {
-    m_appLabel = appLabel;
-    emit appLabelChanged(appLabel);
-  }
-}
-
-QString EmbeddedShellSurface::appIcon() const
-{
-  return m_appIcon;
-}
-
-void EmbeddedShellSurface::setAppIcon(const QString &appIcon)
-{
-  if (m_appIcon != appIcon) {
-    m_appIcon = appIcon;
-    emit appIconChanged(appIcon);
-  }
-}
-
 QSize EmbeddedShellSurface::size() const
 {
   return m_size;
+}
+
+QString EmbeddedShellSurface::uuid() const
+{
+  return m_uuid.toString(QUuid::WithoutBraces);
 }
 
 void EmbeddedShellSurface::sendConfigure(const QSize size)
@@ -230,11 +153,6 @@ void EmbeddedShellSurface::sendVisibleChanged(bool visible)
   send_visible_changed(visible);
 }
 
-QString EmbeddedShellSurface::uuid() const
-{
-  return m_uuid.toString(QUuid::WithoutBraces);
-}
-
 pid_t EmbeddedShellSurface::getClientPid() const
 {
   pid_t pid;
@@ -242,6 +160,226 @@ pid_t EmbeddedShellSurface::getClientPid() const
   gid_t gid;
   wl_client_get_credentials(resource()->client(), &pid, &uid, &gid);
   return pid;
+}
+
+void EmbeddedShellSurface::updateAnchor(EmbeddedShellTypes::Anchor newAnchor)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << newAnchor;
+  m_anchor = newAnchor;
+  emit anchorChanged(newAnchor);
+}
+
+void EmbeddedShellSurface::updateMargin(int newMargin)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << newMargin;
+  m_margin = newMargin;
+  emit marginChanged(newMargin);
+}
+
+void EmbeddedShellSurface::updateSize(const QSize &size)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << m_size << "->" << size;
+  if (m_size != size) {
+    m_size = size;
+    emit sizeChanged(size);
+  }
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,
+                                                             uint32_t anchor)
+{
+  Q_UNUSED(resource)
+  auto newAnchor = static_cast<EmbeddedShellTypes::Anchor>(anchor);
+  updateAnchor(newAnchor);
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_margin(Resource *resource,
+                                                             int32_t margin)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << margin;
+  Q_UNUSED(resource)
+  updateMargin(margin);
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_set_size(Resource *resource,
+                                                           uint32_t width,
+                                                           uint32_t height)
+{
+  Q_UNUSED(resource)
+  updateSize(QSize(width, height));
+}
+
+void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource,
+                                                              wl_resource *shell_surface,
+                                                              const QString &label,
+                                                              const QString &icon,
+                                                              unsigned int sort_index,
+                                                              wl_array *custom_data,
+                                                              wl_resource *parent_view,
+                                                              uint32_t id)
+{
+  Q_UNUSED(shell_surface)
+  EmbeddedShellSurfaceView *parentView = nullptr;
+
+  if (parent_view) {
+    auto surfaceViewResource = QtWaylandServer::surface_view::Resource::fromResource(parent_view);
+    Q_ASSERT(surfaceViewResource);
+
+    auto waylandSurfaceView = surfaceViewResource->object();
+    Q_ASSERT(waylandSurfaceView);
+
+    parentView = dynamic_cast<EmbeddedShellSurfaceView *>(waylandSurfaceView);
+    Q_ASSERT(parentView);
+  }
+
+  auto customDataVariant = array_to_variant(custom_data);
+  qCDebug(shellExt) << Q_FUNC_INFO << label << icon << id;
+  auto view = new EmbeddedShellSurfaceView(label,
+                                           icon,
+                                           sort_index,
+                                           customDataVariant,
+                                           resource->client(),
+                                           parentView,
+                                           id,
+                                           1);
+  emit createView(view);
+}
+
+EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &label,
+                                                   const QString &icon,
+                                                   uint32_t sortIndex,
+                                                   const QVariant &customData,
+                                                   wl_client *client,
+                                                   EmbeddedShellSurfaceView *parentView,
+                                                   int id,
+                                                   int version)
+    : QtWaylandServer::surface_view(client, id, version)
+    , m_label(label)
+    , m_icon(icon)
+    , m_sortIndex(sortIndex)
+    , m_customData(customData)
+    , m_parentView(parentView)
+{
+}
+
+QString EmbeddedShellSurfaceView::label() const
+{
+    return m_label;
+}
+
+QString EmbeddedShellSurfaceView::icon() const
+{
+  return m_icon;
+}
+
+unsigned int EmbeddedShellSurfaceView::sortIndex() const
+{
+  return m_sortIndex;
+}
+
+QVariant EmbeddedShellSurfaceView::customData() const
+{
+  return m_customData;
+}
+
+QString EmbeddedShellSurfaceView::parentUuid() const
+{
+  return m_parentView ? m_parentView->uuid() : QString();
+}
+
+QString EmbeddedShellSurfaceView::uuid() const
+{
+  return m_uuid.toString(QUuid::WithoutBraces);
+}
+
+void EmbeddedShellSurfaceView::select()
+{
+  surface_view::send_selected();
+}
+
+void EmbeddedShellSurfaceView::updateLabel(const QString &label)
+{
+    if (m_label == label) {
+        return;
+    }
+
+    m_label = label;
+    emit labelChanged(label);
+}
+
+
+
+void EmbeddedShellSurfaceView::updateIcon(const QString &icon)
+{
+    if (m_icon == icon) {
+        return;
+    }
+
+    m_icon = icon;
+    emit iconChanged(icon);
+}
+
+void EmbeddedShellSurfaceView::updateSortIndex(unsigned int newSortIndex)
+{
+  if (m_sortIndex == newSortIndex)
+    return;
+  m_sortIndex = newSortIndex;
+  emit sortIndexChanged(m_sortIndex);
+}
+
+
+
+void EmbeddedShellSurfaceView::updateCustomData(const QVariant &customData)
+{
+  if (m_customData == customData)
+    return;
+  m_customData = customData;
+  emit customDataChanged(m_customData);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource,
+                                                      const QString &text)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << text;
+    Q_UNUSED(resource)
+    updateLabel(text);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_icon(Resource *resource,
+                                                     const QString &icon)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << icon;
+    Q_UNUSED(resource)
+    updateIcon(icon);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
+                                                           uint32_t sort_index)
+{
+  Q_UNUSED(resource)
+  updateSortIndex(sort_index);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_custom_data(Resource *resource,
+                                                            wl_array *custom_data)
+{
+  Q_UNUSED(resource)
+  updateCustomData(array_to_variant(custom_data));
+}
+
+void EmbeddedShellSurfaceView::surface_view_select(Resource *resource)
+{
+  Q_UNUSED(resource)
+  emit aboutToBeSelected();
+  QtWaylandServer::surface_view::surface_view_select(resource);
+}
+
+void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource)
+{
+  Q_UNUSED(resource)
+  emit aboutToBeDestroyed();
+  QtWaylandServer::surface_view::surface_view_destroy(resource);
+  deleteLater();
 }
 
 QuickEmbeddedShellIntegration::QuickEmbeddedShellIntegration(QWaylandQuickShellSurfaceItem *item)
@@ -279,307 +417,4 @@ void QuickEmbeddedShellIntegration::handleEmbeddedShellSurfaceDestroyed()
 {
   qCDebug(shellExt) << Q_FUNC_INFO;
   m_shellSurface = nullptr;
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_size(Resource *resource,
-                                                           uint32_t width,
-                                                           uint32_t height)
-{
-    Q_UNUSED(resource)
-    setSize(QSize(width, height));
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_custom_data(Resource *resource,
-                                                                  wl_array *custom_data)
-{
-  Q_UNUSED(resource)
-  setCustomData(array_to_variant(custom_data));
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,
-                                                             uint32_t anchor)
-{
-  Q_UNUSED(resource)
-  auto newAnchor = static_cast<EmbeddedShellTypes::Anchor>(anchor);
-  qCDebug(shellExt) << Q_FUNC_INFO << m_anchor << "->" << newAnchor;
-  if(newAnchor != m_anchor) {
-    m_anchor = newAnchor;
-    emit anchorChanged(m_anchor);
-  }
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource,
-                                                              wl_resource *shell_surface,
-                                                              const QString &appId,
-                                                              const QString &appLabel,
-                                                              const QString &appIcon,
-                                                              const QString &label,
-                                                              const QString &icon,
-                                                              uint32_t sort_index,
-                                                              wl_array *custom_data,
-                                                              uint32_t id)
-{
-  Q_UNUSED(shell_surface)
-  auto customDataVariant = array_to_variant(custom_data);
-  qCDebug(shellExt) << Q_FUNC_INFO << appId << appLabel << appIcon << label << icon << id << customDataVariant;
-  auto view = new EmbeddedShellSurfaceView(appId,
-                                           appLabel,
-                                           appIcon,
-                                           label,
-                                           icon,
-                                           sort_index,
-                                           customDataVariant,
-                                           resource->client(),
-                                           id,
-                                           1);
-  emit createView(view);
-}
-
-EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
-                                                   const QString &label,
-                                                   const QString &icon,
-                                                   uint32_t sort_index,
-                                                   wl_client *client,
-                                                   int id,
-                                                   int version)
-    : QtWaylandServer::surface_view(client, id, version)
-    , m_appId(appId)
-    , m_label(label)
-    , m_icon(icon)
-    , m_sortIndex(sort_index)
-{
-}
-
-EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
-                                                   const QString &appLabel,
-                                                   const QString &appIcon,
-                                                   const QString &label,
-                                                   const QString &icon,
-                                                   uint32_t sort_index,
-                                                   const QVariant &custom_data,
-                                                   wl_client *client,
-                                                   int id,
-                                                   int version)
-    : QtWaylandServer::surface_view(client, id, version)
-    , m_appId(appId)
-    , m_appLabel(appLabel)
-    , m_appIcon(appIcon)
-    , m_label(label)
-    , m_icon(icon)
-    , m_sortIndex(sort_index)
-    , m_customData(custom_data)
-{
-}
-
-QString EmbeddedShellSurfaceView::appId() const
-{
-    return m_appId;
-}
-
-void EmbeddedShellSurfaceView::setAppId(const QString &appId)
-{
-    if (m_appId == appId) {
-        return;
-    }
-
-    // TODO prevent changing after it was initialized.
-    m_appId = appId;
-    emit appIdChanged(appId);
-}
-
-QString EmbeddedShellSurfaceView::appLabel() const
-{
-    return m_appLabel;
-}
-
-void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
-{
-    if (m_appLabel == appLabel) {
-        return;
-    }
-
-    m_appLabel = appLabel;
-    emit appLabelChanged(appLabel);
-}
-
-QString EmbeddedShellSurfaceView::appIcon() const
-{
-    return m_appIcon;
-}
-
-void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
-{
-    if (m_appIcon == appIcon) {
-        return;
-    }
-
-    m_appIcon = appIcon;
-    emit appIconChanged(appIcon);
-}
-
-QString EmbeddedShellSurfaceView::label() const
-{
-    return m_label;
-}
-
-void EmbeddedShellSurfaceView::setLabel(const QString &label)
-{
-    if (m_label == label) {
-        return;
-    }
-
-    m_label = label;
-    emit labelChanged(label);
-}
-
-QString EmbeddedShellSurfaceView::icon() const
-{
-    return m_icon;
-}
-
-void EmbeddedShellSurfaceView::setIcon(const QString &icon)
-{
-    if (m_icon == icon) {
-        return;
-    }
-
-    m_icon = icon;
-    emit iconChanged(icon);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_app_label(Resource *resource,
-                                                          const QString &label)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << label;
-    Q_UNUSED(resource);
-    setAppLabel(label);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_app_icon(Resource *resource,
-                                                         const QString &icon)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << icon;
-    Q_UNUSED(resource);
-    setAppIcon(icon);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource,
-                                                      const QString &text)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << text;
-    Q_UNUSED(resource)
-    setLabel(text);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_icon(Resource *resource,
-                                                     const QString &icon)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << icon;
-    Q_UNUSED(resource)
-    setIcon(icon);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
-                                                           uint32_t sort_index)
-{
-  Q_UNUSED(resource)
-  setSortIndex(sort_index);
-}
-
-void EmbeddedShellSurfaceView::surface_view_set_custom_data(Resource *resource,
-                                                            wl_array *custom_data)
-{
-  Q_UNUSED(resource)
-  setCustomData(array_to_variant(custom_data));
-}
-
-void EmbeddedShellSurfaceView::surface_view_select(Resource *resource)
-{
-  Q_UNUSED(resource)
-  emit aboutToBeSelected();
-  QtWaylandServer::surface_view::surface_view_select(resource);
-}
-
-void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource)
-{
-  Q_UNUSED(resource)
-  emit aboutToBeDestroyed();
-  QtWaylandServer::surface_view::surface_view_destroy(resource);
-  deleteLater();
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_margin(Resource *resource,
-                                                             int32_t margin)
-{
-  qCDebug(shellExt) << Q_FUNC_INFO << margin;
-  Q_UNUSED(resource)
-  setMargin(margin);
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_sort_index(
-    Resource *resource, uint32_t sort_index)
-{
-  qCDebug(shellExt) << Q_FUNC_INFO << sort_index;
-  Q_UNUSED(resource)
-  setSortIndex(sort_index);
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_app_id(
-    Resource *resource, const QString &appId)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << appId;
-    Q_UNUSED(resource)
-    setAppId(appId);
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_app_label(
-    Resource *resource, const QString &appLabel)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << appLabel;
-    Q_UNUSED(resource)
-    setAppLabel(appLabel);
-}
-
-void EmbeddedShellSurface::embedded_shell_surface_set_app_icon(
-    Resource *resource, const QString &appIcon)
-{
-    qCDebug(shellExt) << Q_FUNC_INFO << appIcon;
-    Q_UNUSED(resource)
-    setAppIcon(appIcon);
-}
-
-unsigned int EmbeddedShellSurfaceView::sortIndex() const
-{
-  return m_sortIndex;
-}
-
-void EmbeddedShellSurfaceView::setSortIndex(unsigned int newSortIndex)
-{
-  if (m_sortIndex == newSortIndex)
-    return;
-  m_sortIndex = newSortIndex;
-  emit sortIndexChanged(m_sortIndex);
-}
-
-QVariant EmbeddedShellSurfaceView::customData() const
-{
-  return m_customData;
-}
-
-void EmbeddedShellSurfaceView::setCustomData(const QVariant &customData)
-{
-  if (m_customData == customData)
-    return;
-  m_customData = customData;
-  emit customDataChanged(m_customData);
-}
-
-QString EmbeddedShellSurfaceView::uuid() const
-{
-  return m_uuid.toString(QUuid::WithoutBraces);
-}
-
-void EmbeddedShellSurfaceView::select()
-{
-  surface_view::send_selected();
 }

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -11,9 +11,9 @@ Q_LOGGING_CATEGORY(shellExt, "embeddedshell.compositor")
 
 namespace
 {
-QVariant array_to_variant(wl_array *custom_data)
+QVariantMap array_to_variant_map(wl_array *custom_data)
 {
-  QVariant result;
+  QVariantMap result;
 
   if (custom_data) {
     auto byteArray = QByteArray(static_cast<const char *>(custom_data->data), custom_data->size);
@@ -24,7 +24,7 @@ QVariant array_to_variant(wl_array *custom_data)
 
     if (stream.status() != QDataStream::Status::Ok) {
       qCWarning(shellExt) << Q_FUNC_INFO << "Could not deserialize" << byteArray << "!";
-      result = QVariant();
+      result.clear();
     }
   }
 
@@ -232,7 +232,7 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource
     Q_ASSERT(parentView);
   }
 
-  auto customDataVariant = array_to_variant(custom_data);
+  auto customDataVariant = array_to_variant_map(custom_data);
   qCDebug(shellExt) << Q_FUNC_INFO << label << icon << id;
   auto view = new EmbeddedShellSurfaceView(label,
                                            icon,
@@ -248,7 +248,7 @@ void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &label,
                                                    const QString &icon,
                                                    uint32_t sortIndex,
-                                                   const QVariant &customData,
+                                                   const QVariantMap &customData,
                                                    wl_client *client,
                                                    EmbeddedShellSurfaceView *parentView,
                                                    int id,
@@ -277,7 +277,7 @@ unsigned int EmbeddedShellSurfaceView::sortIndex() const
   return m_sortIndex;
 }
 
-QVariant EmbeddedShellSurfaceView::customData() const
+QVariantMap EmbeddedShellSurfaceView::customData() const
 {
   return m_customData;
 }
@@ -329,7 +329,7 @@ void EmbeddedShellSurfaceView::updateSortIndex(unsigned int newSortIndex)
 
 
 
-void EmbeddedShellSurfaceView::updateCustomData(const QVariant &customData)
+void EmbeddedShellSurfaceView::updateCustomData(const QVariantMap &customData)
 {
   if (m_customData == customData)
     return;
@@ -364,7 +364,7 @@ void EmbeddedShellSurfaceView::surface_view_set_custom_data(Resource *resource,
                                                             wl_array *custom_data)
 {
   Q_UNUSED(resource)
-  updateCustomData(array_to_variant(custom_data));
+  updateCustomData(array_to_variant_map(custom_data));
 }
 
 void EmbeddedShellSurfaceView::surface_view_select(Resource *resource)

--- a/embedded-compositor/embeddedshellextension.cpp
+++ b/embedded-compositor/embeddedshellextension.cpp
@@ -9,18 +9,44 @@
 
 Q_LOGGING_CATEGORY(shellExt, "embeddedshell.compositor")
 
+namespace
+{
+QVariant array_to_variant(wl_array *custom_data)
+{
+  QVariant result;
+
+  if (custom_data) {
+    auto byteArray = QByteArray(static_cast<const char *>(custom_data->data), custom_data->size);
+    QDataStream stream(byteArray);
+    stream.setVersion(QDataStream::Qt_6_8);
+
+    stream >> result;
+
+    if (stream.status() != QDataStream::Status::Ok) {
+      qCWarning(shellExt) << Q_FUNC_INFO << "Could not deserialize" << byteArray << "!";
+      result = QVariant();
+    }
+  }
+
+  return result;
+};
+}
+
 EmbeddedShellExtension::EmbeddedShellExtension(QWaylandCompositor *compositor)
-    : QWaylandShellTemplate<EmbeddedShellExtension>(compositor) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << compositor;
+    : QWaylandShellTemplate<EmbeddedShellExtension>(compositor)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << compositor;
 }
 
 EmbeddedShellExtension::EmbeddedShellExtension()
-    : QWaylandShellTemplate<EmbeddedShellExtension>() {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+    : QWaylandShellTemplate<EmbeddedShellExtension>()
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
 }
 
-void EmbeddedShellExtension::initialize() {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+void EmbeddedShellExtension::initialize()
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
   QWaylandShellTemplate::initialize();
 
   QWaylandCompositor *compositor =
@@ -34,17 +60,24 @@ void EmbeddedShellExtension::initialize() {
 }
 
 void EmbeddedShellExtension::embedded_shell_surface_create(
-    Resource *resource, wl_resource *wl_surface, uint32_t id, uint32_t anchor,
-    uint32_t margin, unsigned int sort_index) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << id << "anchor" << anchor
+    Resource *resource,
+    wl_resource *wl_surface,
+    uint32_t id,
+    uint32_t anchor,
+    uint32_t margin,
+    unsigned int sort_index)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << id << "anchor" << anchor
                     << "margin" << margin;
   Q_UNUSED(resource)
 
   QWaylandSurface *surface = QWaylandSurface::fromResource(wl_surface);
 
   QWaylandResource embeddedShellSurfaceResource(
-      wl_resource_create(resource->client(), &embedded_shell_surface_interface,
-                         wl_resource_get_version(resource->handle), id));
+      wl_resource_create(resource->client(),
+                         &embedded_shell_surface_interface,
+                         wl_resource_get_version(resource->handle),
+                         id));
   auto embeddedShellSurface = QtWayland::fromResource<EmbeddedShellSurface *>(
       embeddedShellSurfaceResource.resource());
 
@@ -68,9 +101,10 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
                                            uint32_t margin, uint32_t sort_index)
     : QWaylandShellSurfaceTemplate<EmbeddedShellSurface>(this),
       m_surface(surface), m_size(QSize{0, 0}), m_anchor(anchor), m_margin(margin),
-      m_sort_index(sort_index) {
+      m_sort_index(sort_index)
+{
   Q_UNUSED(ext)
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << anchor
+  qCDebug(shellExt) << Q_FUNC_INFO << anchor
                     << wl_resource_get_id(resource.resource());
   init(resource.resource());
   setExtensionContainer(surface);
@@ -78,66 +112,131 @@ EmbeddedShellSurface::EmbeddedShellSurface(EmbeddedShellExtension *ext,
 }
 
 QWaylandQuickShellIntegration *
-EmbeddedShellSurface::createIntegration(QWaylandQuickShellSurfaceItem *item) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+EmbeddedShellSurface::createIntegration(QWaylandQuickShellSurfaceItem *item)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
   return new QuickEmbeddedShellIntegration(item);
 }
 
-void EmbeddedShellSurface::setSize(const QSize &size) {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << m_size << "->" << size;
+QWaylandSurface *EmbeddedShellSurface::surface() const
+{
+  return m_surface;
+}
+
+EmbeddedShellTypes::Anchor EmbeddedShellSurface::anchor()
+{
+  return m_anchor;
+}
+
+int EmbeddedShellSurface::margin()
+{
+  return m_margin;
+}
+
+void EmbeddedShellSurface::setSize(const QSize &size)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << m_size << "->" << size;
     if (m_size != size) {
         m_size = size;
-        Q_EMIT sizeChanged(size);
+        emit sizeChanged(size);
     }
 }
 
-void EmbeddedShellSurface::setMargin(int newMargin) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << newMargin;
+QVariant EmbeddedShellSurface::customData() const
+{
+  return m_customData;
+}
+
+void EmbeddedShellSurface::setCustomData(const QVariant &customData)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << m_customData << "->" << customData;
+  if (m_customData != customData) {
+    m_customData = customData;
+    emit customDataChanged(customData);
+  }
+}
+
+void EmbeddedShellSurface::setMargin(int newMargin)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << newMargin;
   m_margin = newMargin;
   emit marginChanged(newMargin);
 }
 
-void EmbeddedShellSurface::setSortIndex(unsigned int sort_index) {
+unsigned int EmbeddedShellSurface::sortIndex()
+{
+  return m_sort_index;
+}
+
+void EmbeddedShellSurface::setSortIndex(unsigned int sort_index)
+{
   m_sort_index = sort_index;
   emit sortIndexChanged(sort_index);
 }
 
-void EmbeddedShellSurface::setAppId(const QString &appId) {
+QString EmbeddedShellSurface::appId() const
+{
+  return m_appId;
+}
+
+void EmbeddedShellSurface::setAppId(const QString &appId)
+{
   if (!m_appId.isEmpty()) {
     return;
   }
   m_appId = appId;
 }
 
-void EmbeddedShellSurface::setAppLabel(const QString &appLabel) {
+QString EmbeddedShellSurface::appLabel() const
+{
+  return m_appLabel;
+}
+
+void EmbeddedShellSurface::setAppLabel(const QString &appLabel)
+{
   if (m_appLabel != appLabel) {
     m_appLabel = appLabel;
-    Q_EMIT appLabelChanged(appLabel);
+    emit appLabelChanged(appLabel);
   }
 }
 
-void EmbeddedShellSurface::setAppIcon(const QString &appIcon) {
+QString EmbeddedShellSurface::appIcon() const
+{
+  return m_appIcon;
+}
+
+void EmbeddedShellSurface::setAppIcon(const QString &appIcon)
+{
   if (m_appIcon != appIcon) {
     m_appIcon = appIcon;
-    Q_EMIT appIconChanged(appIcon);
+    emit appIconChanged(appIcon);
   }
 }
 
-void EmbeddedShellSurface::sendConfigure(const QSize size) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << size;
+QSize EmbeddedShellSurface::size() const
+{
+  return m_size;
+}
+
+void EmbeddedShellSurface::sendConfigure(const QSize size)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << size;
   send_configure(size.width(), size.height());
 }
 
-void EmbeddedShellSurface::sendVisibleChanged(bool visible) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << visible;
+void EmbeddedShellSurface::sendVisibleChanged(bool visible)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << visible;
   send_visible_changed(visible);
 }
 
-QString EmbeddedShellSurface::getUuid() const {
+QString EmbeddedShellSurface::uuid() const
+{
   return m_uuid.toString(QUuid::WithoutBraces);
 }
 
-pid_t EmbeddedShellSurface::getClientPid() const {
+pid_t EmbeddedShellSurface::getClientPid() const
+{
   pid_t pid;
   uid_t uid;
   gid_t gid;
@@ -145,56 +244,94 @@ pid_t EmbeddedShellSurface::getClientPid() const {
   return pid;
 }
 
-QuickEmbeddedShellIntegration::QuickEmbeddedShellIntegration(
-    QWaylandQuickShellSurfaceItem *item)
-    : QWaylandQuickShellIntegration(item), m_item(item),
-      m_shellSurface(
-          qobject_cast<EmbeddedShellSurface *>(item->shellSurface())) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+QuickEmbeddedShellIntegration::QuickEmbeddedShellIntegration(QWaylandQuickShellSurfaceItem *item)
+    : QWaylandQuickShellIntegration(item), m_item(item)
+    , m_shellSurface(qobject_cast<EmbeddedShellSurface *>(item->shellSurface()))
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
   m_item->setSurface(m_shellSurface->surface());
   connect(m_shellSurface, &EmbeddedShellSurface::destroyed, this,
           &QuickEmbeddedShellIntegration::handleEmbeddedShellSurfaceDestroyed);
 }
 
-QuickEmbeddedShellIntegration::~QuickEmbeddedShellIntegration() {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+QuickEmbeddedShellIntegration::~QuickEmbeddedShellIntegration()
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
   m_item->setSurface(nullptr);
 }
 
-void QuickEmbeddedShellIntegration::sendConfigure(const QSize size) {
+EmbeddedShellTypes::Anchor QuickEmbeddedShellIntegration::getAnchor()
+{
+  return m_shellSurface->anchor();
+}
+
+int QuickEmbeddedShellIntegration::getMargin()
+{
+  return m_shellSurface->margin();
+}
+
+void QuickEmbeddedShellIntegration::sendConfigure(const QSize size)
+{
   m_shellSurface->send_configure(size.width(), size.height());
 }
 
-void QuickEmbeddedShellIntegration::handleEmbeddedShellSurfaceDestroyed() {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+void QuickEmbeddedShellIntegration::handleEmbeddedShellSurfaceDestroyed()
+{
+  qCDebug(shellExt) << Q_FUNC_INFO;
   m_shellSurface = nullptr;
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_size(Resource *resource,
                                                            uint32_t width,
-                                                           uint32_t height) {
+                                                           uint32_t height)
+{
     Q_UNUSED(resource)
     setSize(QSize(width, height));
 }
 
+void EmbeddedShellSurface::embedded_shell_surface_set_custom_data(Resource *resource,
+                                                                  wl_array *custom_data)
+{
+  Q_UNUSED(resource)
+  setCustomData(array_to_variant(custom_data));
+}
+
 void EmbeddedShellSurface::embedded_shell_surface_set_anchor(Resource *resource,
-                                                             uint32_t anchor) {
+                                                             uint32_t anchor)
+{
   Q_UNUSED(resource)
   auto newAnchor = static_cast<EmbeddedShellTypes::Anchor>(anchor);
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
+  qCDebug(shellExt) << Q_FUNC_INFO << m_anchor << "->" << newAnchor;
   if(newAnchor != m_anchor) {
     m_anchor = newAnchor;
     emit anchorChanged(m_anchor);
   }
 }
 
-void EmbeddedShellSurface::embedded_shell_surface_view_create(
-    Resource *resource, wl_resource *shell_surface, const QString &appId, const QString &appLabel, const QString &appIcon,
-    const QString &label, const QString &icon, uint32_t sort_index, uint32_t id) {
+void EmbeddedShellSurface::embedded_shell_surface_view_create(Resource *resource,
+                                                              wl_resource *shell_surface,
+                                                              const QString &appId,
+                                                              const QString &appLabel,
+                                                              const QString &appIcon,
+                                                              const QString &label,
+                                                              const QString &icon,
+                                                              uint32_t sort_index,
+                                                              wl_array *custom_data,
+                                                              uint32_t id)
+{
   Q_UNUSED(shell_surface)
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << id;
-  auto view = new EmbeddedShellSurfaceView(appId, appLabel, appIcon, label, icon, sort_index,
-                                           resource->client(), id, 1);
+  auto customDataVariant = array_to_variant(custom_data);
+  qCDebug(shellExt) << Q_FUNC_INFO << appId << appLabel << appIcon << label << icon << id << customDataVariant;
+  auto view = new EmbeddedShellSurfaceView(appId,
+                                           appLabel,
+                                           appIcon,
+                                           label,
+                                           icon,
+                                           sort_index,
+                                           customDataVariant,
+                                           resource->client(),
+                                           id,
+                                           1);
   emit createView(view);
 }
 
@@ -203,7 +340,8 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
                                                    const QString &icon,
                                                    uint32_t sort_index,
                                                    wl_client *client,
-                                                   int id, int version)
+                                                   int id,
+                                                   int version)
     : QtWaylandServer::surface_view(client, id, version)
     , m_appId(appId)
     , m_label(label)
@@ -218,8 +356,10 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
                                                    const QString &label,
                                                    const QString &icon,
                                                    uint32_t sort_index,
+                                                   const QVariant &custom_data,
                                                    wl_client *client,
-                                                   int id, int version)
+                                                   int id,
+                                                   int version)
     : QtWaylandServer::surface_view(client, id, version)
     , m_appId(appId)
     , m_appLabel(appLabel)
@@ -227,6 +367,7 @@ EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(const QString &appId,
     , m_label(label)
     , m_icon(icon)
     , m_sortIndex(sort_index)
+    , m_customData(custom_data)
 {
 }
 
@@ -243,7 +384,7 @@ void EmbeddedShellSurfaceView::setAppId(const QString &appId)
 
     // TODO prevent changing after it was initialized.
     m_appId = appId;
-    Q_EMIT appIdChanged(appId);
+    emit appIdChanged(appId);
 }
 
 QString EmbeddedShellSurfaceView::appLabel() const
@@ -258,7 +399,7 @@ void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
     }
 
     m_appLabel = appLabel;
-    Q_EMIT appLabelChanged(appLabel);
+    emit appLabelChanged(appLabel);
 }
 
 QString EmbeddedShellSurfaceView::appIcon() const
@@ -273,7 +414,7 @@ void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
     }
 
     m_appIcon = appIcon;
-    Q_EMIT appIconChanged(appIcon);
+    emit appIconChanged(appIcon);
 }
 
 QString EmbeddedShellSurfaceView::label() const
@@ -288,7 +429,7 @@ void EmbeddedShellSurfaceView::setLabel(const QString &label)
     }
 
     m_label = label;
-    Q_EMIT labelChanged(label);
+    emit labelChanged(label);
 }
 
 QString EmbeddedShellSurfaceView::icon() const
@@ -303,94 +444,135 @@ void EmbeddedShellSurfaceView::setIcon(const QString &icon)
     }
 
     m_icon = icon;
-    Q_EMIT iconChanged(icon);
+    emit iconChanged(icon);
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_app_label(Resource *resource, const QString &label)
+void EmbeddedShellSurfaceView::surface_view_set_app_label(Resource *resource,
+                                                          const QString &label)
 {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << label;
+    qCDebug(shellExt) << Q_FUNC_INFO << label;
     Q_UNUSED(resource);
     setAppLabel(label);
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_app_icon(Resource *resource, const QString &icon)
+void EmbeddedShellSurfaceView::surface_view_set_app_icon(Resource *resource,
+                                                         const QString &icon)
 {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << icon;
+    qCDebug(shellExt) << Q_FUNC_INFO << icon;
     Q_UNUSED(resource);
     setAppIcon(icon);
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource, const QString &text)
+void EmbeddedShellSurfaceView::surface_view_set_label(Resource *resource,
+                                                      const QString &text)
 {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << text;
+    qCDebug(shellExt) << Q_FUNC_INFO << text;
     Q_UNUSED(resource)
     setLabel(text);
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_icon(Resource *resource, const QString &icon)
+void EmbeddedShellSurfaceView::surface_view_set_icon(Resource *resource,
+                                                     const QString &icon)
 {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << icon;
+    qCDebug(shellExt) << Q_FUNC_INFO << icon;
     Q_UNUSED(resource)
     setIcon(icon);
 }
 
+void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
+                                                           uint32_t sort_index)
+{
+  Q_UNUSED(resource)
+  setSortIndex(sort_index);
+}
+
+void EmbeddedShellSurfaceView::surface_view_set_custom_data(Resource *resource,
+                                                            wl_array *custom_data)
+{
+  Q_UNUSED(resource)
+  setCustomData(array_to_variant(custom_data));
+}
+
+void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource)
+{
+  Q_UNUSED(resource)
+  emit aboutToBeDestroyed();
+  QtWaylandServer::surface_view::surface_view_destroy(resource);
+  deleteLater();
+}
+
 void EmbeddedShellSurface::embedded_shell_surface_set_margin(Resource *resource,
-                                                             int32_t margin) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << margin;
+                                                             int32_t margin)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << margin;
   Q_UNUSED(resource)
   setMargin(margin);
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_sort_index(
-    Resource *resource, uint32_t sort_index) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << sort_index;
+    Resource *resource, uint32_t sort_index)
+{
+  qCDebug(shellExt) << Q_FUNC_INFO << sort_index;
   Q_UNUSED(resource)
   setSortIndex(sort_index);
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_app_id(
-    Resource *resource, const QString &appId) {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appId;
+    Resource *resource, const QString &appId)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << appId;
     Q_UNUSED(resource)
     setAppId(appId);
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_app_label(
-    Resource *resource, const QString &appLabel) {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appLabel;
+    Resource *resource, const QString &appLabel)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << appLabel;
     Q_UNUSED(resource)
     setAppLabel(appLabel);
 }
 
 void EmbeddedShellSurface::embedded_shell_surface_set_app_icon(
-    Resource *resource, const QString &appIcon) {
-    qCDebug(shellExt) << __PRETTY_FUNCTION__ << appIcon;
+    Resource *resource, const QString &appIcon)
+{
+    qCDebug(shellExt) << Q_FUNC_INFO << appIcon;
     Q_UNUSED(resource)
     setAppIcon(appIcon);
 }
 
-unsigned int EmbeddedShellSurfaceView::sortIndex() const { return m_sortIndex; }
+unsigned int EmbeddedShellSurfaceView::sortIndex() const
+{
+  return m_sortIndex;
+}
 
-void EmbeddedShellSurfaceView::setSortIndex(unsigned int newSortIndex) {
+void EmbeddedShellSurfaceView::setSortIndex(unsigned int newSortIndex)
+{
   if (m_sortIndex == newSortIndex)
     return;
   m_sortIndex = newSortIndex;
   emit sortIndexChanged(m_sortIndex);
 }
 
-QString EmbeddedShellSurfaceView::getUuid() const {
+QVariant EmbeddedShellSurfaceView::customData() const
+{
+  return m_customData;
+}
+
+void EmbeddedShellSurfaceView::setCustomData(const QVariant &customData)
+{
+  if (m_customData == customData)
+    return;
+  m_customData = customData;
+  emit customDataChanged(m_customData);
+}
+
+QString EmbeddedShellSurfaceView::uuid() const
+{
   return m_uuid.toString(QUuid::WithoutBraces);
 }
 
-void EmbeddedShellSurfaceView::surface_view_set_sort_index(Resource *resource,
-                                                           uint32_t sort_index) {
-  Q_UNUSED(resource)
-  setSortIndex(sort_index);
-}
-
-void EmbeddedShellSurfaceView::surface_view_destroy(Resource *resource) {
-    Q_UNUSED(resource)
-    emit aboutToBeDestroyed();
-    QtWaylandServer::surface_view::surface_view_destroy(resource);
-    deleteLater();
+void EmbeddedShellSurfaceView::select()
+{
+  surface_view::send_selected();
 }

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -117,7 +117,7 @@ class EmbeddedShellSurfaceView : public QObject,
   Q_PROPERTY(QString label READ label NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon NOTIFY iconChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariant customData NOTIFY customDataChanged)
+  Q_PROPERTY(QVariantMap customData NOTIFY customDataChanged)
   Q_PROPERTY(QString parentUuid READ parentUuid CONSTANT)
   Q_PROPERTY(QString uuid READ uuid CONSTANT)
 
@@ -125,7 +125,7 @@ public:
   EmbeddedShellSurfaceView(const QString &label,
                            const QString &icon,
                            uint32_t sortIndex,
-                           const QVariant &customData,
+                           const QVariantMap &customData,
                            wl_client *client,
                            EmbeddedShellSurfaceView *parentView,
                            int id,
@@ -134,7 +134,7 @@ public:
   QString label() const;
   QString icon() const;
   unsigned int sortIndex() const;
-  QVariant customData() const;
+  QVariantMap customData() const;
   QString parentUuid() const;
   QString uuid() const;
 
@@ -144,7 +144,7 @@ signals:
   void labelChanged(const QString &label);
   void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int index);
-  void customDataChanged(const QVariant &customData);
+  void customDataChanged(const QVariantMap &customData);
   void aboutToBeSelected();
   void aboutToBeDestroyed();
 
@@ -152,7 +152,7 @@ private:
   void updateLabel(const QString &label);
   void updateIcon(const QString &icon);
   void updateSortIndex(unsigned int newSortIndex);
-  void updateCustomData(const QVariant &customData);
+  void updateCustomData(const QVariantMap &customData);
 
 protected:
   void surface_view_set_label(Resource *resource,
@@ -171,7 +171,7 @@ private:
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;
-  QVariant m_customData;
+  QVariantMap m_customData;
   EmbeddedShellSurfaceView * m_parentView = nullptr;
 };
 

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -2,17 +2,17 @@
 
 #pragma once
 
+#include "qwayland-server-embedded-shell.h"
+
 #include <QtWaylandCompositor/QWaylandShellSurfaceTemplate>
 #include <QtWaylandCompositor/QWaylandShellTemplate>
-
-#include "quuid.h"
-#include "qwayland-server-embedded-shell.h"
-#include <QWaylandResource>
 #include <QtWaylandCompositor/QWaylandCompositor>
 #include <QtWaylandCompositor/QWaylandQuickExtension>
-
 #include <QtWaylandCompositor/QWaylandQuickShellIntegration>
 #include <QtWaylandCompositor/QWaylandQuickShellSurfaceItem>
+#include <QWaylandResource>
+
+#include <QUuid>
 
 class EmbeddedShellSurface;
 class EmbeddedShellSurfaceView;
@@ -33,12 +33,13 @@ class EmbeddedShellExtension
 public:
   explicit EmbeddedShellExtension(QWaylandCompositor *compositor);
   explicit EmbeddedShellExtension();
-  void embedded_shell_surface_create(Resource *resource,
-                                     struct ::wl_resource *surface, uint32_t id,
-                                     uint32_t anchor, uint32_t margin,
-                                     uint sort_index) override;
-
   void initialize() override;
+  void embedded_shell_surface_create(Resource *resource,
+                                     struct ::wl_resource *surface,
+                                     uint32_t id,
+                                     uint32_t anchor,
+                                     uint32_t margin) override;
+
 signals:
   void surfaceAdded(EmbeddedShellSurface *surface);
 };
@@ -50,48 +51,23 @@ class EmbeddedShellSurface
   Q_OBJECT
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin NOTIFY marginChanged)
-  Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QString appId READ appId CONSTANT)
-  Q_PROPERTY(QString appLabel READ appLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon NOTIFY appIconChanged)
   Q_PROPERTY(QSize size READ size NOTIFY sizeChanged)
-  Q_PROPERTY(QVariant customData READ customData NOTIFY customDataChanged)
   Q_PROPERTY(QString uuid READ uuid CONSTANT)
 
 public:
-  EmbeddedShellSurface(EmbeddedShellExtension *ext, QWaylandSurface *surface,
+  EmbeddedShellSurface(EmbeddedShellExtension *extension,
+                       QWaylandSurface *surface,
                        const QWaylandResource &resource,
-                       EmbeddedShellTypes::Anchor anchor, uint32_t margin,
-                       uint32_t sort_index);
-  QWaylandQuickShellIntegration *
-  createIntegration(QWaylandQuickShellSurfaceItem *item) override;
+                       EmbeddedShellTypes::Anchor anchor,
+                       uint32_t margin);
+
+  QWaylandQuickShellIntegration *createIntegration(QWaylandQuickShellSurfaceItem *item) override;
 
   QWaylandSurface *surface() const;
 
   EmbeddedShellTypes::Anchor anchor();
-  void setAnchor(embedded_shell_anchor_border newAnchor);
-
   int margin();
-  void setMargin(int newMargin);
-
-  unsigned int sortIndex();
-  void setSortIndex(unsigned int sort_index);
-
-  QString appId() const;
-  void setAppId(const QString &appId);
-
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
-
   QSize size() const;
-  void setSize(const QSize &size);
-
-  QVariant customData() const;
-  void setCustomData(const QVariant &customData);
-
   QString uuid() const;
 
   Q_INVOKABLE void sendConfigure(const QSize size);
@@ -101,23 +77,19 @@ public:
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
-  void sortIndexChanged(unsigned int sort_index);
-  void appIconChanged(const QString &appIcon);
-  void appLabelChanged(const QString &appLabel);
   void sizeChanged(const QSize &size);
-  void customDataChanged(const QVariant &customData);
   void createView(EmbeddedShellSurfaceView *view);
+
+private:
+  void updateAnchor(EmbeddedShellTypes::Anchor newAnchor);
+  void updateMargin(int newMargin);
+  void updateSize(const QSize &size);
 
 private:
   QWaylandSurface *m_surface;
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
-  uint32_t m_sort_index = 0;
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
   QSize m_size;
-  QVariant m_customData;
   QUuid m_uuid = QUuid::createUuid();
 
   // embedded_shell_surface interface
@@ -126,91 +98,49 @@ protected:
                                          uint32_t anchor) override;
   void embedded_shell_surface_set_margin(Resource *resource,
                                          int32_t margin) override;
-  void embedded_shell_surface_set_sort_index(Resource *resource,
-                                             uint32_t sort_index) override;
-  void embedded_shell_surface_set_app_id(Resource *resource,
-                                         const QString &appId) override;
-  void embedded_shell_surface_set_app_label(Resource *resource,
-                                            const QString &label) override;
-  void embedded_shell_surface_set_app_icon(Resource *resource,
-                                           const QString &icon) override;
   void embedded_shell_surface_set_size(Resource *resource,
                                        uint32_t width,
                                        uint32_t height) override;
-  void embedded_shell_surface_set_custom_data(Resource *resource,
-                                              wl_array *custom_data) override;
   void embedded_shell_surface_view_create(Resource *resource,
                                           wl_resource *shell_surface,
-                                          const QString &appId,
-                                          const QString &appLabel,
-                                          const QString &appIcon,
                                           const QString &label,
                                           const QString &icon,
                                           unsigned int sort_index,
                                           wl_array *custom_data,
+                                          wl_resource *parent_view,
                                           uint32_t id) override;
 };
 
 class EmbeddedShellSurfaceView : public QObject,
                                  public QtWaylandServer::surface_view {
   Q_OBJECT
-  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
-  Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
-  Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
+  Q_PROPERTY(QString label READ label NOTIFY labelChanged)
+  Q_PROPERTY(QString icon READ icon NOTIFY iconChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariant customData READ customData NOTIFY customDataChanged)
+  Q_PROPERTY(QVariant customData NOTIFY customDataChanged)
+  Q_PROPERTY(QString parentUuid READ parentUuid CONSTANT)
   Q_PROPERTY(QString uuid READ uuid CONSTANT)
 
 public:
-  EmbeddedShellSurfaceView(const QString &appId,
-                           const QString &label,
+  EmbeddedShellSurfaceView(const QString &label,
                            const QString &icon,
-                           uint32_t sort_index,
+                           uint32_t sortIndex,
+                           const QVariant &customData,
                            wl_client *client,
+                           EmbeddedShellSurfaceView *parentView,
                            int id,
                            int version);
-  EmbeddedShellSurfaceView(const QString &appId,
-                           const QString &appLabel,
-                           const QString &appIcon,
-                           const QString &label,
-                           const QString &icon,
-                           uint32_t sort_index,
-                           const QVariant &custom_data,
-                           wl_client *client,
-                           int id,
-                           int version);
-
-  QString appId() const;
-  void setAppId(const QString &appId);
-
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
 
   QString label() const;
-  void setLabel(const QString &label);
-
   QString icon() const;
-  void setIcon(const QString &icon);
-
   unsigned int sortIndex() const;
-  void setSortIndex(unsigned int newSortIndex);
-
   QVariant customData() const;
-  void setCustomData(const QVariant &customData);
-
+  QString parentUuid() const;
   QString uuid() const;
 
   Q_INVOKABLE void select();
 
 signals:
-  void appIdChanged(const QString &appId);
-  void appLabelChanged(const QString &appLabel);
-  void appIconChanged(const QString &appIcon);
   void labelChanged(const QString &label);
   void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int index);
@@ -218,11 +148,13 @@ signals:
   void aboutToBeSelected();
   void aboutToBeDestroyed();
 
+private:
+  void updateLabel(const QString &label);
+  void updateIcon(const QString &icon);
+  void updateSortIndex(unsigned int newSortIndex);
+  void updateCustomData(const QVariant &customData);
+
 protected:
-  void surface_view_set_app_label(Resource *resource,
-                                  const QString &label) override;
-  void surface_view_set_app_icon(Resource *resource,
-                                 const QString &icon) override;
   void surface_view_set_label(Resource *resource,
                               const QString &text) override;
   void surface_view_set_icon(Resource *resource,
@@ -236,13 +168,11 @@ protected:
 
 private:
   QUuid m_uuid = QUuid::createUuid();
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;
   QVariant m_customData;
+  EmbeddedShellSurfaceView * m_parentView = nullptr;
 };
 
 class QuickEmbeddedShellIntegration : public QWaylandQuickShellIntegration

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -106,6 +106,7 @@ protected:
                                           const QString &label,
                                           const QString &icon,
                                           unsigned int sort_index,
+                                          const QString &persistentId,
                                           wl_array *custom_data,
                                           wl_resource *parent_view,
                                           uint32_t id) override;
@@ -117,14 +118,16 @@ class EmbeddedShellSurfaceView : public QObject,
   Q_PROPERTY(QString label READ label NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon NOTIFY iconChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariantMap customData NOTIFY customDataChanged)
+  Q_PROPERTY(QVariantMap customData READ customData NOTIFY customDataChanged)
   Q_PROPERTY(QString parentUuid READ parentUuid CONSTANT)
   Q_PROPERTY(QString uuid READ uuid CONSTANT)
+  Q_PROPERTY(bool isPersistent READ isPersistent CONSTANT)
 
 public:
   EmbeddedShellSurfaceView(const QString &label,
                            const QString &icon,
                            uint32_t sortIndex,
+                           const QString &persistentId,
                            const QVariantMap &customData,
                            wl_client *client,
                            EmbeddedShellSurfaceView *parentView,
@@ -137,6 +140,7 @@ public:
   QVariantMap customData() const;
   QString parentUuid() const;
   QString uuid() const;
+  bool isPersistent() const;
 
   Q_INVOKABLE void select();
 
@@ -167,7 +171,8 @@ protected:
   void surface_view_destroy(Resource *resource) override;
 
 private:
-  QUuid m_uuid = QUuid::createUuid();
+  bool m_isPersistent = false;
+  QString m_uuid;
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -215,6 +215,7 @@ signals:
   void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int index);
   void customDataChanged(const QVariant &customData);
+  void aboutToBeSelected();
   void aboutToBeDestroyed();
 
 protected:
@@ -230,6 +231,7 @@ protected:
                                    uint32_t sort_index) override;
   void surface_view_set_custom_data(Resource *resource,
                                     wl_array *custom_data) override;
+  void surface_view_select(Resource *resource) override;
   void surface_view_destroy(Resource *resource) override;
 
 private:

--- a/embedded-compositor/embeddedshellextension.h
+++ b/embedded-compositor/embeddedshellextension.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#ifndef EMBEDDEDSHELLEXTENSION_H
-#define EMBEDDEDSHELLEXTENSION_H
+#pragma once
 
 #include <QtWaylandCompositor/QWaylandShellSurfaceTemplate>
 #include <QtWaylandCompositor/QWaylandShellTemplate>
@@ -49,6 +48,16 @@ class EmbeddedShellSurface
       public QtWaylandServer::embedded_shell_surface
 {
   Q_OBJECT
+  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor NOTIFY anchorChanged)
+  Q_PROPERTY(int margin READ margin NOTIFY marginChanged)
+  Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString appId READ appId CONSTANT)
+  Q_PROPERTY(QString appLabel READ appLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon NOTIFY appIconChanged)
+  Q_PROPERTY(QSize size READ size NOTIFY sizeChanged)
+  Q_PROPERTY(QVariant customData READ customData NOTIFY customDataChanged)
+  Q_PROPERTY(QString uuid READ uuid CONSTANT)
+
 public:
   EmbeddedShellSurface(EmbeddedShellExtension *ext, QWaylandSurface *surface,
                        const QWaylandResource &resource,
@@ -57,68 +66,64 @@ public:
   QWaylandQuickShellIntegration *
   createIntegration(QWaylandQuickShellSurfaceItem *item) override;
 
-  QWaylandSurface *surface() const { return m_surface; }
+  QWaylandSurface *surface() const;
 
-  QSize getSize() const { return m_size; }
-  EmbeddedShellTypes::Anchor getAnchor() { return m_anchor; }
-  int getMargin() { return m_margin; }
-  unsigned int sortIndex() { return m_sort_index; }
-  QString appId() const { return m_appId; }
-  QString appLabel() const { return m_appLabel; }
-  QString appIcon() const { return m_appIcon; }
-  Q_PROPERTY(QSize size READ getSize NOTIFY sizeChanged)
-  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ getAnchor NOTIFY anchorChanged)
-  Q_PROPERTY(int margin READ getMargin NOTIFY marginChanged)
-  Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QString appId READ appId CONSTANT)
-  Q_PROPERTY(QString appLabel READ appLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon NOTIFY appIconChanged)
-  Q_PROPERTY(QString uuid READ getUuid CONSTANT)
-
-  void setSize(const QSize &size);
+  EmbeddedShellTypes::Anchor anchor();
   void setAnchor(embedded_shell_anchor_border newAnchor);
+
+  int margin();
   void setMargin(int newMargin);
+
+  unsigned int sortIndex();
   void setSortIndex(unsigned int sort_index);
+
+  QString appId() const;
   void setAppId(const QString &appId);
+
+  QString appLabel() const;
   void setAppLabel(const QString &appLabel);
+
+  QString appIcon() const;
   void setAppIcon(const QString &appIcon);
+
+  QSize size() const;
+  void setSize(const QSize &size);
+
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
+
+  QString uuid() const;
+
   Q_INVOKABLE void sendConfigure(const QSize size);
   Q_INVOKABLE void sendVisibleChanged(bool visible);
-  QString getUuid() const;
   pid_t getClientPid() const;
 
 signals:
-  void sizeChanged(const QSize &size);
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sort_index);
   void appIconChanged(const QString &appIcon);
   void appLabelChanged(const QString &appLabel);
+  void sizeChanged(const QSize &size);
+  void customDataChanged(const QVariant &customData);
   void createView(EmbeddedShellSurfaceView *view);
 
 private:
   QWaylandSurface *m_surface;
-  QSize m_size;
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
   QString m_appId;
   QString m_appLabel;
   QString m_appIcon;
+  QSize m_size;
+  QVariant m_customData;
   QUuid m_uuid = QUuid::createUuid();
 
   // embedded_shell_surface interface
 protected:
-  void embedded_shell_surface_set_size(Resource *resource,
-                                       uint32_t width,
-                                       uint32_t height) override;
   void embedded_shell_surface_set_anchor(Resource *resource,
                                          uint32_t anchor) override;
-  void embedded_shell_surface_view_create(Resource *resource,
-                                          wl_resource *shell_surface,
-                                          const QString &appId, const QString &appLabel, const QString &appIcon,
-                                          const QString &label, const QString &icon, unsigned int sort_index,
-                                          uint32_t id) override;
   void embedded_shell_surface_set_margin(Resource *resource,
                                          int32_t margin) override;
   void embedded_shell_surface_set_sort_index(Resource *resource,
@@ -129,6 +134,21 @@ protected:
                                             const QString &label) override;
   void embedded_shell_surface_set_app_icon(Resource *resource,
                                            const QString &icon) override;
+  void embedded_shell_surface_set_size(Resource *resource,
+                                       uint32_t width,
+                                       uint32_t height) override;
+  void embedded_shell_surface_set_custom_data(Resource *resource,
+                                              wl_array *custom_data) override;
+  void embedded_shell_surface_view_create(Resource *resource,
+                                          wl_resource *shell_surface,
+                                          const QString &appId,
+                                          const QString &appLabel,
+                                          const QString &appIcon,
+                                          const QString &label,
+                                          const QString &icon,
+                                          unsigned int sort_index,
+                                          wl_array *custom_data,
+                                          uint32_t id) override;
 };
 
 class EmbeddedShellSurfaceView : public QObject,
@@ -140,53 +160,76 @@ class EmbeddedShellSurfaceView : public QObject,
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QString uuid READ getUuid CONSTANT)
+  Q_PROPERTY(QVariant customData READ customData NOTIFY customDataChanged)
+  Q_PROPERTY(QString uuid READ uuid CONSTANT)
+
 public:
-  EmbeddedShellSurfaceView(const QString &appId, const QString &label, const QString &icon,
-                           uint32_t sort_index, wl_client *client, int id, int version);
-  EmbeddedShellSurfaceView(const QString &appId, const QString &appLabel, const QString &appIcon,
-                           const QString &label, const QString &icon, uint32_t sort_index,
-                           wl_client *client, int id, int version);
+  EmbeddedShellSurfaceView(const QString &appId,
+                           const QString &label,
+                           const QString &icon,
+                           uint32_t sort_index,
+                           wl_client *client,
+                           int id,
+                           int version);
+  EmbeddedShellSurfaceView(const QString &appId,
+                           const QString &appLabel,
+                           const QString &appIcon,
+                           const QString &label,
+                           const QString &icon,
+                           uint32_t sort_index,
+                           const QVariant &custom_data,
+                           wl_client *client,
+                           int id,
+                           int version);
 
   QString appId() const;
   void setAppId(const QString &appId);
-  Q_SIGNAL void appIdChanged(const QString &appId);
 
   QString appLabel() const;
   void setAppLabel(const QString &appLabel);
-  Q_SIGNAL void appLabelChanged(const QString &appLabel);
 
   QString appIcon() const;
   void setAppIcon(const QString &appIcon);
-  Q_SIGNAL void appIconChanged(const QString &appIcon);
 
   QString label() const;
   void setLabel(const QString &label);
-  Q_SIGNAL void labelChanged(const QString &label);
 
   QString icon() const;
   void setIcon(const QString &icon);
-  Q_SIGNAL void iconChanged(const QString &icon);
 
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int newSortIndex);
 
-  QString getUuid() const;
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
 
-public slots:
-  void select() { surface_view::send_selected(); }
+  QString uuid() const;
+
+  Q_INVOKABLE void select();
 
 signals:
+  void appIdChanged(const QString &appId);
+  void appLabelChanged(const QString &appLabel);
+  void appIconChanged(const QString &appIcon);
+  void labelChanged(const QString &label);
+  void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int index);
+  void customDataChanged(const QVariant &customData);
   void aboutToBeDestroyed();
 
 protected:
-  void surface_view_set_app_label(Resource *resource, const QString &label) override;
-  void surface_view_set_app_icon(Resource *resource, const QString &icon) override;
-  void surface_view_set_label(Resource *resource, const QString &text) override;
-  void surface_view_set_icon(Resource *resource, const QString &icon) override;
+  void surface_view_set_app_label(Resource *resource,
+                                  const QString &label) override;
+  void surface_view_set_app_icon(Resource *resource,
+                                 const QString &icon) override;
+  void surface_view_set_label(Resource *resource,
+                              const QString &text) override;
+  void surface_view_set_icon(Resource *resource,
+                             const QString &icon) override;
   void surface_view_set_sort_index(Resource *resource,
                                    uint32_t sort_index) override;
+  void surface_view_set_custom_data(Resource *resource,
+                                    wl_array *custom_data) override;
   void surface_view_destroy(Resource *resource) override;
 
 private:
@@ -197,6 +240,7 @@ private:
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;
+  QVariant m_customData;
 };
 
 class QuickEmbeddedShellIntegration : public QWaylandQuickShellIntegration
@@ -209,11 +253,11 @@ public:
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ getAnchor)
   Q_PROPERTY(int margin READ getMargin)
 
-  EmbeddedShellTypes::Anchor getAnchor() { return m_shellSurface->getAnchor(); }
-  int getMargin() { return m_shellSurface->getMargin(); }
+  EmbeddedShellTypes::Anchor getAnchor();
+  int getMargin();
   void sendConfigure(const QSize size);
 
-private slots:
+private:
   void handleEmbeddedShellSurfaceDestroyed();
 
 private:
@@ -222,5 +266,3 @@ private:
 };
 
 Q_COMPOSITOR_DECLARE_QUICK_EXTENSION_CLASS(EmbeddedShellExtension)
-
-#endif // EMBEDDEDSHELLEXTENSION_H

--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -268,6 +268,10 @@ WaylandCompositor {
             var entry = surfaces[shellSurface];
             console.log("compositor: create view", view , "with entry", entry);
 
+            view.aboutToBeSelected.connect(function() {
+                taskSwitcherInterface.currentView = view.uuid;
+            })
+
             view.aboutToBeDestroyed.connect(function() {
                 for (var i = 0; i < count; i++) {
                     var data = get(i).data;

--- a/embedded-compositor/sortfilterproxymodel.h
+++ b/embedded-compositor/sortfilterproxymodel.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
-#ifndef SORTFILTERPROXYMODEL_H
-#define SORTFILTERPROXYMODEL_H
+#pragma once
 
 #include <QSortFilterProxyModel>
 
@@ -46,12 +45,10 @@ protected:
   bool filterAcceptsRow(int sourceRow,
                         const QModelIndex &sourceParent) const override;
 
-private slots:
+private:
   void initRoles();
 
 private:
   QString m_sortFunction;
   QString m_acceptFunction;
 };
-
-#endif // SORTFILTERPROXYMODEL_H

--- a/embeddedplatform/embeddedcompositordbusclient.h
+++ b/embeddedplatform/embeddedcompositordbusclient.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef DBUSCLIENT_H
-#define DBUSCLIENT_H
+#pragma once
 
 #include <QObject>
 #include <QDBusConnection>
@@ -18,27 +17,26 @@ class EmbeddedCompositorDBusInterfacePrivate;
 
 class EmbeddedCompositorDBusInterface : public QObject
 {
-    Q_OBJECT
+  Q_OBJECT
 
-    Q_DECLARE_PRIVATE_D(m_d, EmbeddedCompositorDBusInterface)
-    QScopedPointer<EmbeddedCompositorDBusInterfacePrivate> m_d;
+  Q_DECLARE_PRIVATE_D(m_d, EmbeddedCompositorDBusInterface)
+  QScopedPointer<EmbeddedCompositorDBusInterfacePrivate> m_d;
+
 public:
-    explicit EmbeddedCompositorDBusInterface(QObject *parent = nullptr);
-    ~EmbeddedCompositorDBusInterface() override;
+  explicit EmbeddedCompositorDBusInterface(QObject *parent = nullptr);
+  ~EmbeddedCompositorDBusInterface() override;
 
-    Q_INVOKABLE void openTaskSwitcher();
-    Q_INVOKABLE void closeTaskSwitcher();
+  Q_INVOKABLE void openTaskSwitcher();
+  Q_INVOKABLE void closeTaskSwitcher();
 
-    Q_INVOKABLE void showGlobalOverlay(const QString &message);
-    Q_INVOKABLE void hideGlobalOverlay();
-    Q_INVOKABLE uint notify(const QString &summary, const QString &body, const QStringList &actions);
+  Q_INVOKABLE void showGlobalOverlay(const QString &message);
+  Q_INVOKABLE void hideGlobalOverlay();
+  Q_INVOKABLE uint notify(const QString &summary, const QString &body, const QStringList &actions);
 
-    Q_INVOKABLE void setOrientation(const QString &orientation);
+  Q_INVOKABLE void setOrientation(const QString &orientation);
 
-Q_SIGNALS:
-    void notificationActionInvoked(unsigned int id, const QString &action);
-    void notificationClosed(unsigned int id, unsigned int);
+signals:
+  void notificationActionInvoked(unsigned int id, const QString &action);
+  void notificationClosed(unsigned int id, unsigned int);
 
 };
-
-#endif // DBUSCLIENT_H

--- a/embeddedplatform/embeddedplatform.cpp
+++ b/embeddedplatform/embeddedplatform.cpp
@@ -10,7 +10,7 @@ EmbeddedPlatform *EmbeddedPlatform::s_instance = nullptr;
 
 EmbeddedPlatform::EmbeddedPlatform()
 {
-  qDebug() << __PRETTY_FUNCTION__;
+  qDebug() << Q_FUNC_INFO;
 }
 
 EmbeddedPlatform *EmbeddedPlatform::instance()

--- a/embeddedplatform/embeddedplatform.h
+++ b/embeddedplatform/embeddedplatform.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDPLATFORM_H
-#define EMBEDDEDPLATFORM_H
+#pragma once
 
 #include "embeddedshellsurface.h"
 
@@ -24,5 +23,3 @@ public:
 signals:
   void shellSurfaceCreated(EmbeddedShellSurface *, QWindow *);
 };
-
-#endif // EMBEDDEDPLATFORM_H

--- a/embeddedplatform/embeddedshell.cpp
+++ b/embeddedplatform/embeddedshell.cpp
@@ -9,19 +9,26 @@ Q_LOGGING_CATEGORY(shellExt, "embeddedshell.client")
 EmbeddedShell::EmbeddedShell(QtWayland::embedded_shell *embeddedShell)
   : m_embeddedShell(embeddedShell)
 {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__;
+  qCDebug(shellExt) << Q_FUNC_INFO;
 }
 
-EmbeddedShellSurface *
-EmbeddedShell::createSurface(QtWaylandClient::QWaylandWindow *window,
-                             EmbeddedShellTypes::Anchor anchor, uint32_t margin,
-                             unsigned int sort_index) {
-  qCDebug(shellExt) << __PRETTY_FUNCTION__ << anchor << margin;
+EmbeddedShellSurface *EmbeddedShell::createSurface(QtWaylandClient::QWaylandWindow *window,
+                                                   EmbeddedShellTypes::Anchor anchor,
+                                                   uint32_t margin,
+                                                   unsigned int sort_index) {
+  qCDebug(shellExt) << Q_FUNC_INFO << anchor << margin << sort_index;
   auto surface = m_embeddedShell->surface_create(
-      window->wlSurface(), static_cast<embedded_shell_anchor_border>(anchor),
-      margin, sort_index);
+      window->wlSurface(),
+      static_cast<embedded_shell_anchor_border>(anchor),
+      margin,
+      sort_index);
+
   const QSize size{0, 0};
-  auto ess =
-      new EmbeddedShellSurface(surface, window, size, anchor, margin, sort_index);
+  auto ess = new EmbeddedShellSurface(surface,
+                                      window,
+                                      size,
+                                      anchor,
+                                      margin,
+                                      sort_index);
   return ess;
 }

--- a/embeddedplatform/embeddedshell.cpp
+++ b/embeddedplatform/embeddedshell.cpp
@@ -14,21 +14,18 @@ EmbeddedShell::EmbeddedShell(QtWayland::embedded_shell *embeddedShell)
 
 EmbeddedShellSurface *EmbeddedShell::createSurface(QtWaylandClient::QWaylandWindow *window,
                                                    EmbeddedShellTypes::Anchor anchor,
-                                                   uint32_t margin,
-                                                   unsigned int sort_index) {
-  qCDebug(shellExt) << Q_FUNC_INFO << anchor << margin << sort_index;
+                                                   uint32_t margin) {
+  qCDebug(shellExt) << Q_FUNC_INFO << anchor << margin;
   auto surface = m_embeddedShell->surface_create(
       window->wlSurface(),
       static_cast<embedded_shell_anchor_border>(anchor),
-      margin,
-      sort_index);
+      margin);
 
   const QSize size{0, 0};
   auto ess = new EmbeddedShellSurface(surface,
                                       window,
                                       size,
                                       anchor,
-                                      margin,
-                                      sort_index);
+                                      margin);
   return ess;
 }

--- a/embeddedplatform/embeddedshell.h
+++ b/embeddedplatform/embeddedshell.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELL_H
-#define EMBEDDEDSHELL_H
+#pragma once
 
 #include "embeddedshellsurface.h"
 #include <QLoggingCategory>
@@ -24,10 +23,9 @@ public:
   explicit EmbeddedShell(QtWayland::embedded_shell *embeddedShell);
   EmbeddedShellSurface *createSurface(QtWaylandClient::QWaylandWindow *window,
                                       EmbeddedShellTypes::Anchor anchor,
-                                      uint32_t margin, unsigned int sort_index);
+                                      uint32_t margin,
+                                      unsigned int sort_index);
 
 private:
   QtWayland::embedded_shell *m_embeddedShell;
 };
-
-#endif // EMBEDDEDSHELL_H

--- a/embeddedplatform/embeddedshell.h
+++ b/embeddedplatform/embeddedshell.h
@@ -23,8 +23,7 @@ public:
   explicit EmbeddedShell(QtWayland::embedded_shell *embeddedShell);
   EmbeddedShellSurface *createSurface(QtWaylandClient::QWaylandWindow *window,
                                       EmbeddedShellTypes::Anchor anchor,
-                                      uint32_t margin,
-                                      unsigned int sort_index);
+                                      uint32_t margin);
 
 private:
   QtWayland::embedded_shell *m_embeddedShell;

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -43,25 +43,142 @@ EmbeddedShellSurfacePrivate::~EmbeddedShellSurfacePrivate()
 {
 }
 
-QSize EmbeddedShellSurface::getSize() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_size;
-}
-
-EmbeddedShellTypes::Anchor EmbeddedShellSurface::getAnchor() const
+EmbeddedShellTypes::Anchor EmbeddedShellSurface::anchor() const
 {
   Q_D(const EmbeddedShellSurface);
   return d->m_anchor;
 }
 
-unsigned int EmbeddedShellSurface::getSortIndex() const
+void EmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor anchor)
+{
+  Q_D(EmbeddedShellSurface);
+  if (d->m_anchor != anchor) {
+    d->m_anchor = anchor;
+    d->set_anchor(static_cast<embedded_shell_anchor_border>(anchor));
+    emit anchorChanged(anchor);
+  }
+}
+
+int EmbeddedShellSurface::margin() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_margin;
+}
+
+void EmbeddedShellSurface::setMargin(int margin)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_margin != margin) {
+    d->m_margin = margin;
+    d->set_margin(margin);
+    emit marginChanged(margin);
+  }
+}
+
+unsigned int EmbeddedShellSurface::sortIndex() const
 {
   Q_D(const EmbeddedShellSurface);
   return d->m_sort_index;
 }
 
-bool EmbeddedShellSurface::getVisible()
+void EmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_sort_index != sortIndex) {
+    d->m_sort_index = sortIndex;
+    d->set_sort_index(sortIndex);
+    emit sortIndexChanged(sortIndex);
+  }
+}
+
+QString EmbeddedShellSurface::appId() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_app_id;
+}
+
+void EmbeddedShellSurface::setAppId(const QString &appId)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_app_id != appId) {
+    d->m_app_id = appId;
+    d->set_app_id(appId);
+    emit appIdChanged(appId);
+  }
+}
+
+QString EmbeddedShellSurface::appLabel() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_app_label;
+}
+
+void EmbeddedShellSurface::setAppLabel(const QString &appLabel)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_app_label != appLabel) {
+    d->m_app_label = appLabel;
+    d->set_app_label(appLabel);
+    emit appLabelChanged(appLabel);
+  }
+}
+
+QString EmbeddedShellSurface::appIcon() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_app_icon;
+}
+
+void EmbeddedShellSurface::setAppIcon(const QString &appIcon)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_app_icon != appIcon) {
+    d->m_app_icon = appIcon;
+    d->set_app_icon(appIcon);
+    emit appIconChanged(appIcon);
+  }
+}
+
+QSize EmbeddedShellSurface::size() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_size;
+}
+
+void EmbeddedShellSurface::setSize(const QSize &size)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_size != size) {
+    d->m_size = size;
+    d->set_size(size.width(), size.height());
+    emit sizeChanged(size);
+  }
+}
+
+QVariant EmbeddedShellSurface::customData() const
+{
+  Q_D(const EmbeddedShellSurface);
+  return d->m_custom_data;
+}
+
+void EmbeddedShellSurface::setCustomData(const QVariant &customData)
+{
+  Q_D(EmbeddedShellSurface);
+
+  if (d->m_custom_data != customData) {
+    d->m_custom_data = customData;
+    d->set_custom_data(EmbeddedShellSurfaceViewPrivate::serializeVariant(customData));
+    emit customDataChanged(customData);
+  }
+}
+
+bool EmbeddedShellSurface::visible() const
 {
   Q_D(const EmbeddedShellSurface);
   return d->m_visible;
@@ -91,17 +208,17 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_visible_changed(int32_t
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
-                                                           uint32_t sort_index)
+                                                           uint32_t sortIndex)
 {
-  return createView(QString(), QString(), QString(), label, icon, sort_index);
+  return createView(QString(), QString(), QString(), label, icon, sortIndex);
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            const QString &label,
                                                            const QString &icon,
-                                                           uint32_t sort_index)
+                                                           uint32_t sortIndex)
 {
-  return createView(appId, QString(), QString(), label, icon, sort_index);
+  return createView(appId, QString(), QString(), label, icon, sortIndex);
 }
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
@@ -109,16 +226,18 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
                                                            const QString &appIcon,
                                                            const QString &label,
                                                            const QString &icon,
-                                                           uint32_t sort_index)
+                                                           uint32_t sortIndex,
+                                                           const QVariant &custom_data)
 {
   Q_D(EmbeddedShellSurface);
   auto waylandView = d->view_create(d->embedded_shell_surface::object(),
-                             appId,
-                             appLabel,
-                             appIcon,
-                             label,
-                             icon,
-                             sort_index);
+                                    appId,
+                                    appLabel,
+                                    appIcon,
+                                    label,
+                                    icon,
+                                    sortIndex,
+                                    EmbeddedShellSurfaceViewPrivate::serializeVariant(custom_data));
 
   auto view = new EmbeddedShellSurfaceView(waylandView, this);
 
@@ -129,7 +248,8 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
   viewPrivate->m_appIcon = appIcon;
   viewPrivate->m_label = label;
   viewPrivate->m_icon = icon;
-  viewPrivate->m_sortIndex = sort_index;
+  viewPrivate->m_sortIndex = sortIndex;
+  viewPrivate->m_customData = custom_data;
 
   connect(view, &EmbeddedShellSurfaceView::selectedChanged, d, [view, d](bool selected) {
     if (selected) {
@@ -149,47 +269,4 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
 QtWaylandClient::QWaylandShellSurface *EmbeddedShellSurface::shellSurface()
 {
   return d_ptr.data();
-}
-
-void EmbeddedShellSurface::sendSize(const QSize &size)
-{
-  Q_D(EmbeddedShellSurface);
-  // Check version here if it were versioned.
-  d->set_size(size.width(), size.height());
-}
-
-void EmbeddedShellSurface::sendAnchor(EmbeddedShellTypes::Anchor anchor)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_anchor(static_cast<embedded_shell_anchor_border>(anchor));
-}
-
-void EmbeddedShellSurface::sendMargin(int margin)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_margin(margin);
-}
-
-void EmbeddedShellSurface::sendSortIndex(unsigned int sortIndex)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_sort_index(sortIndex);
-}
-
-void EmbeddedShellSurface::sendAppId(const QString &appId)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_app_id(appId);
-}
-
-void EmbeddedShellSurface::sendAppLabel(const QString &appLabel)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_app_label(appLabel);
-}
-
-void EmbeddedShellSurface::sendAppIcon(const QString &appIcon)
-{
-  Q_D(EmbeddedShellSurface);
-  d->set_app_icon(appIcon);
 }

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -120,6 +120,7 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_visible_changed(int32_t
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
                                                            uint32_t sortIndex,
+                                                           const QString &persistentId,
                                                            const QVariantMap &customData,
                                                            EmbeddedShellSurfaceView* parentView)
 {
@@ -128,6 +129,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                     label,
                                     icon,
                                     sortIndex,
+                                    persistentId,
                                     EmbeddedShellSurfaceViewPrivate::serializeVariantMap(customData),
                                     parentView ? const_cast<::surface_view *>(parentView->view()) : nullptr);
 
@@ -139,6 +141,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
   viewPrivate->m_label = label;
   viewPrivate->m_icon = icon;
   viewPrivate->m_sortIndex = sortIndex;
+  viewPrivate->m_persistentId = persistentId;
   viewPrivate->m_customData = customData;
 
   connect(view, &EmbeddedShellSurfaceView::selectedUpdated, d, [view, d](bool selected, bool explicitly) {

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -6,19 +6,17 @@
 #include "embeddedshellsurfaceview_p.h"
 #include <QtWaylandClient/private/qwaylandwindow_p.h>
 
-EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
+EmbeddedShellSurface::EmbeddedShellSurface(struct ::embedded_shell_surface *shellSurface,
                                            QtWaylandClient::QWaylandWindow *window,
                                            const QSize &size,
                                            EmbeddedShellTypes::Anchor anchor,
-                                           uint32_t margin,
-                                           uint32_t sort_index)
+                                           uint32_t margin)
     : d_ptr(new EmbeddedShellSurfacePrivate(this,
-                                            shell_surface,
+                                            shellSurface,
                                             window,
                                             size,
                                             anchor,
-                                            margin,
-                                            sort_index))
+                                            margin))
 {
 }
 
@@ -27,14 +25,12 @@ EmbeddedShellSurfacePrivate::EmbeddedShellSurfacePrivate(EmbeddedShellSurface *q
                                                          QtWaylandClient::QWaylandWindow *window,
                                                          const QSize &size,
                                                          EmbeddedShellTypes::Anchor anchor,
-                                                         uint32_t margin,
-                                                         uint32_t sort_index)
+                                                         uint32_t margin)
     : QWaylandShellSurface(window)
     , QtWayland::embedded_shell_surface(shell_surface)
     , m_size(size)
     , m_anchor(anchor)
     , m_margin(margin)
-    , m_sort_index(sort_index)
     , q_ptr(q)
 {
 }
@@ -76,74 +72,6 @@ void EmbeddedShellSurface::setMargin(int margin)
   }
 }
 
-unsigned int EmbeddedShellSurface::sortIndex() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_sort_index;
-}
-
-void EmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
-{
-  Q_D(EmbeddedShellSurface);
-
-  if (d->m_sort_index != sortIndex) {
-    d->m_sort_index = sortIndex;
-    d->set_sort_index(sortIndex);
-    emit sortIndexChanged(sortIndex);
-  }
-}
-
-QString EmbeddedShellSurface::appId() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_app_id;
-}
-
-void EmbeddedShellSurface::setAppId(const QString &appId)
-{
-  Q_D(EmbeddedShellSurface);
-
-  if (d->m_app_id != appId) {
-    d->m_app_id = appId;
-    d->set_app_id(appId);
-    emit appIdChanged(appId);
-  }
-}
-
-QString EmbeddedShellSurface::appLabel() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_app_label;
-}
-
-void EmbeddedShellSurface::setAppLabel(const QString &appLabel)
-{
-  Q_D(EmbeddedShellSurface);
-
-  if (d->m_app_label != appLabel) {
-    d->m_app_label = appLabel;
-    d->set_app_label(appLabel);
-    emit appLabelChanged(appLabel);
-  }
-}
-
-QString EmbeddedShellSurface::appIcon() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_app_icon;
-}
-
-void EmbeddedShellSurface::setAppIcon(const QString &appIcon)
-{
-  Q_D(EmbeddedShellSurface);
-
-  if (d->m_app_icon != appIcon) {
-    d->m_app_icon = appIcon;
-    d->set_app_icon(appIcon);
-    emit appIconChanged(appIcon);
-  }
-}
-
 QSize EmbeddedShellSurface::size() const
 {
   Q_D(const EmbeddedShellSurface);
@@ -158,23 +86,6 @@ void EmbeddedShellSurface::setSize(const QSize &size)
     d->m_size = size;
     d->set_size(size.width(), size.height());
     emit sizeChanged(size);
-  }
-}
-
-QVariant EmbeddedShellSurface::customData() const
-{
-  Q_D(const EmbeddedShellSurface);
-  return d->m_custom_data;
-}
-
-void EmbeddedShellSurface::setCustomData(const QVariant &customData)
-{
-  Q_D(EmbeddedShellSurface);
-
-  if (d->m_custom_data != customData) {
-    d->m_custom_data = customData;
-    d->set_custom_data(EmbeddedShellSurfaceViewPrivate::serializeVariant(customData));
-    emit customDataChanged(customData);
   }
 }
 
@@ -208,54 +119,55 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_visible_changed(int32_t
 
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
-                                                           uint32_t sortIndex)
-{
-  return createView(QString(), QString(), QString(), label, icon, sortIndex);
-}
-
-EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
-                                                           const QString &label,
-                                                           const QString &icon,
-                                                           uint32_t sortIndex)
-{
-  return createView(appId, QString(), QString(), label, icon, sortIndex);
-}
-
-EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &appId,
-                                                           const QString &appLabel,
-                                                           const QString &appIcon,
-                                                           const QString &label,
-                                                           const QString &icon,
                                                            uint32_t sortIndex,
-                                                           const QVariant &custom_data)
+                                                           const QVariant &customData,
+                                                           EmbeddedShellSurfaceView* parentView)
 {
   Q_D(EmbeddedShellSurface);
   auto waylandView = d->view_create(d->embedded_shell_surface::object(),
-                                    appId,
-                                    appLabel,
-                                    appIcon,
                                     label,
                                     icon,
                                     sortIndex,
-                                    EmbeddedShellSurfaceViewPrivate::serializeVariant(custom_data));
+                                    EmbeddedShellSurfaceViewPrivate::serializeVariant(customData),
+                                    parentView ? const_cast<::surface_view *>(parentView->view()) : nullptr);
 
   auto view = new EmbeddedShellSurfaceView(waylandView, this);
 
   auto *viewPrivate = EmbeddedShellSurfaceViewPrivate::get(view);
 
-  viewPrivate->m_appId = appId;
-  viewPrivate->m_appLabel = appLabel;
-  viewPrivate->m_appIcon = appIcon;
+  viewPrivate->m_parentView = parentView;
   viewPrivate->m_label = label;
   viewPrivate->m_icon = icon;
   viewPrivate->m_sortIndex = sortIndex;
-  viewPrivate->m_customData = custom_data;
+  viewPrivate->m_customData = customData;
 
-  connect(view, &EmbeddedShellSurfaceView::selectedChanged, d, [view, d](bool selected) {
-    if (selected) {
+  connect(view, &EmbeddedShellSurfaceView::selectedUpdated, d, [view, d](bool selected, bool explicitly) {
+    if (selected && explicitly) {
       if (d->m_selectedView != view) {
+
         if (d->m_selectedView) {
-          d->m_selectedView->setSelected(false);
+          d->m_selectedView->updateTopLevel(false);
+        }
+
+        view->updateTopLevel(true);
+
+        auto selectedViews = QList<EmbeddedShellSurfaceView *>() << view;
+        auto selectedView = view->parentView();
+
+        while (selectedView)
+        {
+          selectedView->updateSelected(true);
+          selectedViews << selectedView;
+          selectedView = selectedView->parentView();
+        }
+
+        EmbeddedShellSurfaceView *previousView = d->m_selectedView;
+        while (previousView) {
+          if (!selectedViews.contains(previousView))
+          {
+            previousView->updateSelected(false);
+          }
+          previousView = previousView->parentView();
         }
 
         d->m_selectedView = view;

--- a/embeddedplatform/embeddedshellsurface.cpp
+++ b/embeddedplatform/embeddedshellsurface.cpp
@@ -120,7 +120,7 @@ void EmbeddedShellSurfacePrivate::embedded_shell_surface_visible_changed(int32_t
 EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                                            const QString &icon,
                                                            uint32_t sortIndex,
-                                                           const QVariant &customData,
+                                                           const QVariantMap &customData,
                                                            EmbeddedShellSurfaceView* parentView)
 {
   Q_D(EmbeddedShellSurface);
@@ -128,7 +128,7 @@ EmbeddedShellSurfaceView *EmbeddedShellSurface::createView(const QString &label,
                                     label,
                                     icon,
                                     sortIndex,
-                                    EmbeddedShellSurfaceViewPrivate::serializeVariant(customData),
+                                    EmbeddedShellSurfaceViewPrivate::serializeVariantMap(customData),
                                     parentView ? const_cast<::surface_view *>(parentView->view()) : nullptr);
 
   auto view = new EmbeddedShellSurfaceView(waylandView, this);

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -50,7 +50,7 @@ public:
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
                                        uint32_t sortIndex,
-                                       const QVariant &customData = QVariant(),
+                                       const QVariantMap &customData = QVariantMap(),
                                        EmbeddedShellSurfaceView* parentView = nullptr);
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -24,22 +24,16 @@ class Q_DECL_EXPORT EmbeddedShellSurface : public QObject
   QScopedPointer<EmbeddedShellSurfacePrivate> d_ptr;
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
-  Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(QSize size READ size WRITE setSize NOTIFY sizeChanged)
-  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
 
   Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
 
 public:
-  EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
+  EmbeddedShellSurface(struct ::embedded_shell_surface *shellSurface,
                        QtWaylandClient::QWaylandWindow *window,
                        const QSize &size,
                        EmbeddedShellTypes::Anchor anchor,
-                       uint32_t margin,
-                       uint32_t sort_index);
+                       uint32_t margin);
 
 public:
   EmbeddedShellTypes::Anchor anchor() const;
@@ -48,53 +42,22 @@ public:
   int margin() const;
   void setMargin(int margin);
 
-  unsigned int sortIndex() const;
-  void setSortIndex(unsigned int sortIndex);
-
-  QString appId() const;
-  void setAppId(const QString &appId);
-
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
-
   QSize size() const;
   void setSize(const QSize &size);
-
-  QVariant customData() const;
-  void setCustomData(const QVariant &customData);
 
   bool visible() const;
 
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
-                                       uint32_t sort_index);
-
-  EmbeddedShellSurfaceView *createView(const QString &appId,
-                                       const QString &label,
-                                       const QString &icon,
-                                       uint32_t sort_index);
-
-  EmbeddedShellSurfaceView *createView(const QString &appId,
-                                       const QString &appLabel,
-                                       const QString &appIcon,
-                                       const QString &label,
-                                       const QString &icon,
-                                       uint32_t sort_index,
-                                       const QVariant &custom_data = QVariant());
+                                       uint32_t sortIndex,
+                                       const QVariant &customData = QVariant(),
+                                       EmbeddedShellSurfaceView* parentView = nullptr);
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();
 
 signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
-  void sortIndexChanged(unsigned int sortIndex);
-  void appIdChanged(const QString &appId);
-  void appLabelChanged(const QString &appLabel);
-  void appIconChanged(const QString &appIcon);
   void sizeChanged(const QSize &size);
-  void customDataChanged(const QVariant &customData);
   void visibleChanged(bool visible);
 };

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLSURFACE_H
-#define EMBEDDEDSHELLSURFACE_H
+#pragma once
 
 #include "embeddedshelltypes.h"
 
 #include <QObject>
+#include <QVariant>
 
 class EmbeddedShellSurfaceView;
 class EmbeddedShellSurfacePrivate;
@@ -22,46 +22,79 @@ class Q_DECL_EXPORT EmbeddedShellSurface : public QObject
   Q_OBJECT
   Q_DECLARE_PRIVATE(EmbeddedShellSurface)
   QScopedPointer<EmbeddedShellSurfacePrivate> d_ptr;
+  Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
+  Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
+  Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
+  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
+  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+  Q_PROPERTY(QSize size READ size WRITE setSize NOTIFY sizeChanged)
+  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
+
+  Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
 
 public:
   EmbeddedShellSurface(struct ::embedded_shell_surface *shell_surface,
                        QtWaylandClient::QWaylandWindow *window,
                        const QSize &size,
-                       EmbeddedShellTypes::Anchor anchor, uint32_t margin,
+                       EmbeddedShellTypes::Anchor anchor,
+                       uint32_t margin,
                        uint32_t sort_index);
 
-  QSize getSize() const;
-  EmbeddedShellTypes::Anchor getAnchor() const;
-  unsigned int getSortIndex() const;
-  bool getVisible();
+public:
+  EmbeddedShellTypes::Anchor anchor() const;
+  void setAnchor(EmbeddedShellTypes::Anchor anchor);
+
+  int margin() const;
+  void setMargin(int margin);
+
+  unsigned int sortIndex() const;
+  void setSortIndex(unsigned int sortIndex);
+
+  QString appId() const;
+  void setAppId(const QString &appId);
+
+  QString appLabel() const;
+  void setAppLabel(const QString &appLabel);
+
+  QString appIcon() const;
+  void setAppIcon(const QString &appIcon);
+
+  QSize size() const;
+  void setSize(const QSize &size);
+
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
+
+  bool visible() const;
 
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
                                        uint32_t sort_index);
+
   EmbeddedShellSurfaceView *createView(const QString &appId,
                                        const QString &label,
                                        const QString &icon,
                                        uint32_t sort_index);
+
   EmbeddedShellSurfaceView *createView(const QString &appId,
                                        const QString &appLabel,
                                        const QString &appIcon,
                                        const QString &label,
                                        const QString &icon,
-                                       uint32_t sort_index);
+                                       uint32_t sort_index,
+                                       const QVariant &custom_data = QVariant());
 
   QtWaylandClient::QWaylandShellSurface *shellSurface();
 
 signals:
+  void anchorChanged(EmbeddedShellTypes::Anchor anchor);
+  void marginChanged(int margin);
+  void sortIndexChanged(unsigned int sortIndex);
+  void appIdChanged(const QString &appId);
+  void appLabelChanged(const QString &appLabel);
+  void appIconChanged(const QString &appIcon);
+  void sizeChanged(const QSize &size);
+  void customDataChanged(const QVariant &customData);
   void visibleChanged(bool visible);
-
-public slots:
-  void sendSize(const QSize &size);
-  void sendAnchor(EmbeddedShellTypes::Anchor anchor);
-  void sendMargin(int margin);
-  void sendSortIndex(unsigned int sortIndex);
-  void sendAppId(const QString &appId);
-  void sendAppLabel(const QString &appLabe);
-  void sendAppIcon(const QString &appIcon);
 };
-
-#endif // EMBEDDEDSHELLSURFACE_H

--- a/embeddedplatform/embeddedshellsurface.h
+++ b/embeddedplatform/embeddedshellsurface.h
@@ -50,6 +50,7 @@ public:
   EmbeddedShellSurfaceView *createView(const QString &label,
                                        const QString &icon,
                                        uint32_t sortIndex,
+                                       const QString &persistentId = QString(),
                                        const QVariantMap &customData = QVariantMap(),
                                        EmbeddedShellSurfaceView* parentView = nullptr);
 

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -21,8 +21,7 @@ public:
                               QtWaylandClient::QWaylandWindow *window,
                               const QSize &size,
                               EmbeddedShellTypes::Anchor anchor,
-                              uint32_t margin,
-                              uint32_t sort_index);
+                              uint32_t margin);
 
   ~EmbeddedShellSurfacePrivate() override;
 
@@ -32,11 +31,6 @@ private:
   QSize m_size;
   EmbeddedShellTypes::Anchor m_anchor;
   uint32_t m_margin = 0;
-  uint32_t m_sort_index = 0;
-  QString m_app_id;
-  QString m_app_label;
-  QString m_app_icon;
-  QVariant m_custom_data;
 
   bool m_visible = false;
   QSize m_pendingSize = {0, 0};

--- a/embeddedplatform/embeddedshellsurface_p.h
+++ b/embeddedplatform/embeddedshellsurface_p.h
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLSURFACE_P_H
-#define EMBEDDEDSHELLSURFACE_P_H
+#pragma once
 
 #include "embeddedshellsurface.h"
 #include "qwayland-embedded-shell.h"
 
 #include <QPointer>
+#include <QVariant>
 #include <QtWaylandClient/private/qwaylandshellsurface_p.h>
 
 class EmbeddedShellSurfacePrivate : public QtWaylandClient::QWaylandShellSurface,
@@ -21,13 +21,10 @@ public:
                               QtWaylandClient::QWaylandWindow *window,
                               const QSize &size,
                               EmbeddedShellTypes::Anchor anchor,
-                              uint32_t margin, uint32_t sort_index);
+                              uint32_t margin,
+                              uint32_t sort_index);
 
   ~EmbeddedShellSurfacePrivate() override;
-
-  QSize getSize() const { return m_size; }
-  EmbeddedShellTypes::Anchor getAnchor() const { return m_anchor; }
-  uint32_t getMargin() const { return m_margin; }
 
   void applyConfigure() override;
 
@@ -36,6 +33,11 @@ private:
   EmbeddedShellTypes::Anchor m_anchor;
   uint32_t m_margin = 0;
   uint32_t m_sort_index = 0;
+  QString m_app_id;
+  QString m_app_label;
+  QString m_app_icon;
+  QVariant m_custom_data;
+
   bool m_visible = false;
   QSize m_pendingSize = {0, 0};
   QPointer<EmbeddedShellSurfaceView> m_selectedView;
@@ -45,5 +47,3 @@ protected:
   void embedded_shell_surface_configure(int32_t width, int32_t height) override;
   void embedded_shell_surface_visible_changed(int32_t visible) override;
 };
-
-#endif // EMBEDDEDSHELLSURFACE_P_H

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -106,6 +106,12 @@ void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
   emit sortIndexChanged(sortIndex);
 }
 
+QString EmbeddedShellSurfaceView::persistentId() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_persistentId;
+}
+
 QVariantMap EmbeddedShellSurfaceView::customData() const
 {
   Q_D(const EmbeddedShellSurfaceView);
@@ -149,7 +155,7 @@ const surface_view *EmbeddedShellSurfaceView::view() const
 void EmbeddedShellSurfaceView::updateSelected(bool selected, bool explicitly)
 {
   Q_D(EmbeddedShellSurfaceView);
-  if (d->m_selected == selected)
+  if (d->m_selected == selected && !explicitly)
     return;
 
   d->m_selected = selected;

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -3,8 +3,6 @@
 #include "embeddedshellsurfaceview.h"
 #include "embeddedshellsurfaceview_p.h"
 
-#include <QDebug>
-
 EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(EmbeddedShellSurfaceView *q,
                                                                  ::surface_view *view,
                                                                  EmbeddedShellSurface *surf)
@@ -28,7 +26,6 @@ EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedSh
 
 void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
 {
-  qDebug() << Q_FUNC_INFO;
   Q_Q(EmbeddedShellSurfaceView);
   q->setSelected(true);
 }
@@ -165,3 +162,10 @@ void EmbeddedShellSurfaceView::setSelected(bool selected)
   d->m_selected = selected;
   emit selectedChanged(selected);
 }
+
+void EmbeddedShellSurfaceView::select()
+{
+  Q_D(EmbeddedShellSurfaceView);
+  d->select();
+}
+

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -9,8 +9,8 @@ EmbeddedShellSurfaceViewPrivate::EmbeddedShellSurfaceViewPrivate(EmbeddedShellSu
     : QObject(surf)
     , QtWayland::surface_view(view)
     , q_ptr(q)
-    , m_sortIndex(0)
     , m_selected(false)
+    , m_topLevel(false)
 {
 }
 
@@ -27,7 +27,7 @@ EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedSh
 void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
 {
   Q_Q(EmbeddedShellSurfaceView);
-  q->setSelected(true);
+  q->updateSelected(true, true);
 }
 
 QByteArray EmbeddedShellSurfaceViewPrivate::serializeVariant(const QVariant &variant)
@@ -46,42 +46,16 @@ QByteArray EmbeddedShellSurfaceViewPrivate::serializeVariant(const QVariant &var
   return byteArray;
 }
 
-EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
-                                                   EmbeddedShellSurface *surf)
-    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surf))
+EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view, EmbeddedShellSurface *surface)
+    : d_ptr(new EmbeddedShellSurfaceViewPrivate(this, view, surface))
 {
+  connect(this, &EmbeddedShellSurfaceView::selectedUpdated, this, &EmbeddedShellSurfaceView::selectedChanged);
 }
 
-QString EmbeddedShellSurfaceView::appLabel() const
+EmbeddedShellSurfaceView *EmbeddedShellSurfaceView::parentView() const
 {
   Q_D(const EmbeddedShellSurfaceView);
-  return d->m_appLabel;
-}
-
-void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_appLabel == appLabel)
-    return;
-  d->m_appLabel = appLabel;
-  d->set_app_label(appLabel);
-  emit appLabelChanged(appLabel);
-}
-
-QString EmbeddedShellSurfaceView::appIcon() const
-{
-  Q_D(const EmbeddedShellSurfaceView);
-  return d->m_appIcon;
-}
-
-void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
-{
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_appIcon == appIcon)
-    return;
-  d->m_appIcon = appIcon;
-  d->set_app_icon(appIcon);
-  emit appIconChanged(appIcon);
+  return d->m_parentView;
 }
 
 QString EmbeddedShellSurfaceView::label() const
@@ -154,13 +128,10 @@ bool EmbeddedShellSurfaceView::selected() const
   return d->m_selected;
 }
 
-void EmbeddedShellSurfaceView::setSelected(bool selected)
+bool EmbeddedShellSurfaceView::topLevel() const
 {
-  Q_D(EmbeddedShellSurfaceView);
-  if (d->m_selected == selected)
-    return;
-  d->m_selected = selected;
-  emit selectedChanged(selected);
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_topLevel;
 }
 
 void EmbeddedShellSurfaceView::select()
@@ -169,3 +140,27 @@ void EmbeddedShellSurfaceView::select()
   d->select();
 }
 
+const surface_view *EmbeddedShellSurfaceView::view() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->object();
+}
+
+void EmbeddedShellSurfaceView::updateSelected(bool selected, bool explicitly)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_selected == selected)
+    return;
+
+  d->m_selected = selected;
+  emit selectedUpdated(selected, explicitly);
+}
+
+void EmbeddedShellSurfaceView::updateTopLevel(bool topLevel)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_topLevel == topLevel)
+    return;
+  d->m_topLevel = topLevel;
+  emit topLevelChanged(topLevel);
+}

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -28,9 +28,25 @@ EmbeddedShellSurfaceViewPrivate *EmbeddedShellSurfaceViewPrivate::get(EmbeddedSh
 
 void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
 {
-  qDebug() << __PRETTY_FUNCTION__;
+  qDebug() << Q_FUNC_INFO;
   Q_Q(EmbeddedShellSurfaceView);
   q->setSelected(true);
+}
+
+QByteArray EmbeddedShellSurfaceViewPrivate::serializeVariant(const QVariant &variant)
+{
+  QByteArray byteArray;
+  QDataStream stream(&byteArray, QDataStream::WriteOnly);
+  stream.setVersion(QDataStream::Qt_6_8);
+  stream << variant;
+
+  if (stream.status() != QDataStream::Status::Ok)
+  {
+    qWarning() << Q_FUNC_INFO << "Could not serialize" << variant << "!";
+    byteArray.clear();
+  }
+
+  return byteArray;
 }
 
 EmbeddedShellSurfaceView::EmbeddedShellSurfaceView(::surface_view *view,
@@ -52,7 +68,7 @@ void EmbeddedShellSurfaceView::setAppLabel(const QString &appLabel)
     return;
   d->m_appLabel = appLabel;
   d->set_app_label(appLabel);
-  Q_EMIT appLabelChanged(appLabel);
+  emit appLabelChanged(appLabel);
 }
 
 QString EmbeddedShellSurfaceView::appIcon() const
@@ -68,7 +84,7 @@ void EmbeddedShellSurfaceView::setAppIcon(const QString &appIcon)
     return;
   d->m_appIcon = appIcon;
   d->set_app_icon(appIcon);
-  Q_EMIT appIconChanged(appIcon);
+  emit appIconChanged(appIcon);
 }
 
 QString EmbeddedShellSurfaceView::label() const
@@ -84,7 +100,7 @@ void EmbeddedShellSurfaceView::setLabel(const QString &label)
     return;
   d->m_label = label;
   d->set_label(label);
-  Q_EMIT labelChanged(label);
+  emit labelChanged(label);
 }
 
 QString EmbeddedShellSurfaceView::icon() const
@@ -100,7 +116,7 @@ void EmbeddedShellSurfaceView::setIcon(const QString &icon)
     return;
   d->m_icon = icon;
   d->set_icon(icon);
-  Q_EMIT iconChanged(icon);
+  emit iconChanged(icon);
 }
 
 unsigned int EmbeddedShellSurfaceView::sortIndex() const
@@ -116,7 +132,23 @@ void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
     return;
   d->m_sortIndex = sortIndex;
   d->set_sort_index(sortIndex);
-  Q_EMIT sortIndexChanged(sortIndex);
+  emit sortIndexChanged(sortIndex);
+}
+
+QVariant EmbeddedShellSurfaceView::customData() const
+{
+  Q_D(const EmbeddedShellSurfaceView);
+  return d->m_customData;
+}
+
+void EmbeddedShellSurfaceView::setCustomData(const QVariant &customData)
+{
+  Q_D(EmbeddedShellSurfaceView);
+  if (d->m_customData == customData)
+    return;
+  d->m_customData = customData;
+  d->set_custom_data(EmbeddedShellSurfaceViewPrivate::serializeVariant(customData));
+  emit customDataChanged(customData);
 }
 
 bool EmbeddedShellSurfaceView::selected() const
@@ -131,5 +163,5 @@ void EmbeddedShellSurfaceView::setSelected(bool selected)
   if (d->m_selected == selected)
     return;
   d->m_selected = selected;
-  Q_EMIT selectedChanged(selected);
+  emit selectedChanged(selected);
 }

--- a/embeddedplatform/embeddedshellsurfaceview.cpp
+++ b/embeddedplatform/embeddedshellsurfaceview.cpp
@@ -30,16 +30,16 @@ void EmbeddedShellSurfaceViewPrivate::surface_view_selected()
   q->updateSelected(true, true);
 }
 
-QByteArray EmbeddedShellSurfaceViewPrivate::serializeVariant(const QVariant &variant)
+QByteArray EmbeddedShellSurfaceViewPrivate::serializeVariantMap(const QVariantMap &variantMap)
 {
   QByteArray byteArray;
   QDataStream stream(&byteArray, QDataStream::WriteOnly);
   stream.setVersion(QDataStream::Qt_6_8);
-  stream << variant;
+  stream << variantMap;
 
   if (stream.status() != QDataStream::Status::Ok)
   {
-    qWarning() << Q_FUNC_INFO << "Could not serialize" << variant << "!";
+    qWarning() << Q_FUNC_INFO << "Could not serialize" << variantMap << "!";
     byteArray.clear();
   }
 
@@ -106,19 +106,19 @@ void EmbeddedShellSurfaceView::setSortIndex(unsigned int sortIndex)
   emit sortIndexChanged(sortIndex);
 }
 
-QVariant EmbeddedShellSurfaceView::customData() const
+QVariantMap EmbeddedShellSurfaceView::customData() const
 {
   Q_D(const EmbeddedShellSurfaceView);
   return d->m_customData;
 }
 
-void EmbeddedShellSurfaceView::setCustomData(const QVariant &customData)
+void EmbeddedShellSurfaceView::setCustomData(const QVariantMap &customData)
 {
   Q_D(EmbeddedShellSurfaceView);
   if (d->m_customData == customData)
     return;
   d->m_customData = customData;
-  d->set_custom_data(EmbeddedShellSurfaceViewPrivate::serializeVariant(customData));
+  d->set_custom_data(EmbeddedShellSurfaceViewPrivate::serializeVariantMap(customData));
   emit customDataChanged(customData);
 }
 

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -15,20 +15,16 @@ class EmbeddedShellSurfaceView : public QObject
   Q_OBJECT
   Q_DECLARE_PRIVATE(EmbeddedShellSurfaceView)
   QScopedPointer<EmbeddedShellSurfaceViewPrivate> d_ptr;
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+  Q_PROPERTY(EmbeddedShellSurfaceView *parentView READ parentView CONSTANT)
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
-  Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged)
+  Q_PROPERTY(bool selected READ selected NOTIFY selectedChanged)
+  Q_PROPERTY(bool topLevel READ topLevel NOTIFY topLevelChanged)
 
 public:
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
+  EmbeddedShellSurfaceView *parentView() const;
 
   QString label() const;
   void setLabel(const QString &label);
@@ -43,21 +39,27 @@ public:
   void setCustomData(const QVariant &customData);
 
   bool selected() const;
-  void setSelected(bool selected);
+
+  bool topLevel() const;
 
   void select();
 
+  const ::surface_view *view() const;
+
 signals:
-  void appLabelChanged(const QString &appLabel);
-  void appIconChanged(const QString &appIcon);
   void labelChanged(const QString &label);
   void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int sortIndex);
   void customDataChanged(const QVariant &customData);
+  void selectedUpdated(bool selected, bool explicitly = false);
   void selectedChanged(bool selected);
+  void topLevelChanged(bool topLevel);
+
+private:
+  void updateSelected(bool selected, bool explicitly = false);
+  void updateTopLevel(bool topLevel);
 
 private:
   friend class EmbeddedShellSurface;
-  EmbeddedShellSurfaceView(struct ::surface_view *view,
-                           EmbeddedShellSurface *surf);
+  EmbeddedShellSurfaceView(struct ::surface_view *view, EmbeddedShellSurface *surface);
 };

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -19,6 +19,7 @@ class EmbeddedShellSurfaceView : public QObject
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString persistentId READ persistentId CONSTANT)
   Q_PROPERTY(QVariantMap customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(bool selected READ selected NOTIFY selectedChanged)
   Q_PROPERTY(bool topLevel READ topLevel NOTIFY topLevelChanged)
@@ -34,6 +35,8 @@ public:
 
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
+
+  QString persistentId() const;
 
   QVariantMap customData() const;
   void setCustomData(const QVariantMap &customData);

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -19,7 +19,7 @@ class EmbeddedShellSurfaceView : public QObject
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
+  Q_PROPERTY(QVariantMap customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(bool selected READ selected NOTIFY selectedChanged)
   Q_PROPERTY(bool topLevel READ topLevel NOTIFY topLevelChanged)
 
@@ -35,8 +35,8 @@ public:
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
 
-  QVariant customData() const;
-  void setCustomData(const QVariant &customData);
+  QVariantMap customData() const;
+  void setCustomData(const QVariantMap &customData);
 
   bool selected() const;
 
@@ -50,7 +50,7 @@ signals:
   void labelChanged(const QString &label);
   void iconChanged(const QString &icon);
   void sortIndexChanged(unsigned int sortIndex);
-  void customDataChanged(const QVariant &customData);
+  void customDataChanged(const QVariantMap &customData);
   void selectedUpdated(bool selected, bool explicitly = false);
   void selectedChanged(bool selected);
   void topLevelChanged(bool topLevel);

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLSURFACEVIEW_H
-#define EMBEDDEDSHELLSURFACEVIEW_H
+#pragma once
 
 #include "embeddedshellsurface.h"
 
@@ -21,37 +20,42 @@ class EmbeddedShellSurfaceView : public QObject
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(bool selected READ selected WRITE setSelected NOTIFY selectedChanged)
 
 public:
   QString appLabel() const;
   void setAppLabel(const QString &appLabel);
-  Q_SIGNAL void appLabelChanged(const QString &appLabel);
 
   QString appIcon() const;
   void setAppIcon(const QString &appIcon);
-  Q_SIGNAL void appIconChanged(const QString &appIcon);
 
   QString label() const;
   void setLabel(const QString &label);
-  Q_SIGNAL void labelChanged(const QString &label);
 
   QString icon() const;
   void setIcon(const QString &icon);
-  Q_SIGNAL void iconChanged(const QString &icon);
 
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
-  Q_SIGNAL void sortIndexChanged(unsigned int sortIndex);
+
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
 
   bool selected() const;
   void setSelected(bool selected);
-  Q_SIGNAL void selectedChanged(bool selected);
+
+signals:
+  void appLabelChanged(const QString &appLabel);
+  void appIconChanged(const QString &appIcon);
+  void labelChanged(const QString &label);
+  void iconChanged(const QString &icon);
+  void sortIndexChanged(unsigned int sortIndex);
+  void customDataChanged(const QVariant &customData);
+  void selectedChanged(bool selected);
 
 private:
   friend class EmbeddedShellSurface;
   EmbeddedShellSurfaceView(struct ::surface_view *view,
                            EmbeddedShellSurface *surf);
 };
-
-#endif // EMBEDDEDSHELLSURFACEVIEW_H

--- a/embeddedplatform/embeddedshellsurfaceview.h
+++ b/embeddedplatform/embeddedshellsurfaceview.h
@@ -45,6 +45,8 @@ public:
   bool selected() const;
   void setSelected(bool selected);
 
+  void select();
+
 signals:
   void appLabelChanged(const QString &appLabel);
   void appIconChanged(const QString &appIcon);

--- a/embeddedplatform/embeddedshellsurfaceview_p.h
+++ b/embeddedplatform/embeddedshellsurfaceview_p.h
@@ -32,6 +32,7 @@ public:
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;
+  QString m_persistentId;
   QVariantMap m_customData;
   bool m_selected;
   bool m_topLevel;

--- a/embeddedplatform/embeddedshellsurfaceview_p.h
+++ b/embeddedplatform/embeddedshellsurfaceview_p.h
@@ -28,12 +28,11 @@ public:
 
   EmbeddedShellSurfaceView *q_ptr = nullptr;
 
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
+  EmbeddedShellSurfaceView *m_parentView = nullptr;
   QString m_label;
   QString m_icon;
-  uint32_t m_sortIndex;
+  uint32_t m_sortIndex = 0;
   QVariant m_customData;
   bool m_selected;
+  bool m_topLevel;
 };

--- a/embeddedplatform/embeddedshellsurfaceview_p.h
+++ b/embeddedplatform/embeddedshellsurfaceview_p.h
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLSURFACEVIEW_P_H
-#define EMBEDDEDSHELLSURFACEVIEW_P_H
+#pragma once
 
 #include "embeddedshellsurfaceview.h"
 #include "qwayland-embedded-shell.h"
+
+#include <QVariant>
 
 class EmbeddedShellSurfaceViewPrivate : public QObject,
                                         public QtWayland::surface_view
@@ -23,6 +24,8 @@ public:
 
   void surface_view_selected() override;
 
+  static QByteArray serializeVariant(const QVariant &variant);
+
   EmbeddedShellSurfaceView *q_ptr = nullptr;
 
   QString m_appId;
@@ -31,6 +34,6 @@ public:
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex;
+  QVariant m_customData;
   bool m_selected;
 };
-#endif // EMBEDDEDSHELLSURFACEVIEW_P_H

--- a/embeddedplatform/embeddedshellsurfaceview_p.h
+++ b/embeddedplatform/embeddedshellsurfaceview_p.h
@@ -24,7 +24,7 @@ public:
 
   void surface_view_selected() override;
 
-  static QByteArray serializeVariant(const QVariant &variant);
+  static QByteArray serializeVariantMap(const QVariantMap &variantMap);
 
   EmbeddedShellSurfaceView *q_ptr = nullptr;
 
@@ -32,7 +32,7 @@ public:
   QString m_label;
   QString m_icon;
   uint32_t m_sortIndex = 0;
-  QVariant m_customData;
+  QVariantMap m_customData;
   bool m_selected;
   bool m_topLevel;
 };

--- a/embeddedplatform/embeddedshelltypes.h
+++ b/embeddedplatform/embeddedshelltypes.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLTYPES_H
-#define EMBEDDEDSHELLTYPES_H
+#pragma once
 
 #include <QObject>
 
@@ -12,5 +11,3 @@ namespace EmbeddedShellTypes
   #include "embeddedshellanchor.h"
   Q_ENUM_NS(Anchor)
 } // namespace EmbeddedShellTypes
-
-#endif // EMBEDDEDSHELLTYPES_H

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -1,122 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="embedded_shell">
-	<copyright>
+        <copyright>
 	FIXME
 	</copyright>
 
-	<interface name="embedded_shell_surface" version="1">
-		<request name="destroy" type="destructor"></request>
-		<request name="set_anchor">
-			<arg name="anchor" type="uint" />
+        <interface name="embedded_shell_surface" version="1">
+	        <request name="destroy" type="destructor"/>
+
+                <request name="set_anchor">
+		        <arg name="anchor" type="uint"/>
 		</request>
-		<request name="set_sort_index">
-			<arg name="sort_index" type="uint" />
+
+                <request name="set_margin">
+		        <arg name="margin" type="int"/>
 		</request>
-		<request name="set_margin">
-			<arg name="margin" type="int" />
+
+                <request name="set_sort_index">
+		        <arg name="sort_index" type="uint"/>
 		</request>
-		<request name="set_app_id"><!-- TODO should probably be since="3" -->
-			<description summary="Set the application ID of the application"/>
+
+                <request name="set_app_id">
+		        <description summary="Set the application ID of the application"/>
 			<arg name="label" type="string"/>
 		</request>
-		<request name="set_app_label"><!-- TODO should probably be since="3" -->
-			<description summary="Set the user-visible name of the application"/>
+
+                <request name="set_app_label">
+		        <description summary="Set the user-visible name of the application"/>
 			<arg name="label" type="string"/>
 		</request>
-		<request name="set_app_icon"><!-- TODO should probably be since="3" -->
-			<description summary="Set the icon name of this application"/>
+
+                <request name="set_app_icon">
+		        <description summary="Set the icon name of this application"/>
 			<arg name="icon" type="string"/>
 		</request>
 
-		<request name="set_size"><!-- TODO should probably be since="2" -->
-			<description summary="Sets the size of the surface">
-				Sets the size of the surface in surface-local coordinates. The compositor will display the surface
+                <request name="set_size">
+		        <description summary="Sets the size of the surface">
+			        Sets the size of the surface in surface-local coordinates. The compositor will display the surface
 				with respect to its anchors.
 
-				If you pass 0 for either value, the compositor will assign it and inform you of the assignment in the
+                                If you pass 0 for either value, the compositor will assign it and inform you of the assignment in the
 				configure event. You must set your anchor to opposite edges in the dimensions you omit.
 			</description>
-			<arg name="width" type="uint" />
-			<arg name="height" type="uint" />
+			<arg name="width" type="uint"/>
+			<arg name="height" type="uint"/>
 		</request>
 
-		<event name="configure">
-			<description summary="suggest resize">
-		The configure event asks the client to resize its surface.
-		The width and height arguments specify the size of the window
-		in surface local coordinates.
-		</description>
-			<arg name="width" type="int" />
-			<arg name="height" type="int" />
-		</event>
+                <request name="set_custom_data">
+		        <arg name="custom_data" type="array"/>
+		</request>
 
-                <event name="visible_changed">
-		        <arg name="visible" type="int" />
-		</event>
+                <request name="view_create">
+		        <description summary="create an embedded shell surface_view">
+			        Creates an Embedded Shell Surface.
 
-		<request name="view_create">
-			<description summary="create an embedded shell surface_view">
-				Creates an Embedded Shell Surface.
-
-				The app_id identifies the logical application this surface belongs to.
+                                The app_id identifies the logical application this surface belongs to.
 				The app_label can be empty at which point the label will be used.
 				The app_icon can be empty at which point the icon will be used.
 			</description>
-			<arg name="shell_surface" type="object" interface="embedded_shell_surface" />
+			<arg name="shell_surface" type="object" interface="embedded_shell_surface"/>
 			<arg name="app_id" type="string" summary="The application ID"/>
 			<arg name="app_label" type="string" summary="The user-visible name of the application"/>
 			<arg name="app_icon" type="string" summary="The icon name of the application"/>
 			<arg name="label" type="string" summary="The user-visible label for this particular view"/>
 			<arg name="icon" type="string" summary="The icon name of this particular view"/>
-			<arg name="sort_index" type="uint" />
-			<arg name="new_view_id" type="new_id" interface="surface_view" />
+			<arg name="sort_index" type="uint"/>
+			<arg name="custom_data" type="array"/>
+			<arg name="new_view_id" type="new_id" interface="surface_view"/>
 		</request>
+
+                <event name="configure">
+		        <description summary="suggest resize">
+			        The configure event asks the client to resize its surface.
+				The width and height arguments specify the size of the window
+				in surface local coordinates.
+			</description>
+			<arg name="width" type="int"/>
+			<arg name="height" type="int"/>
+		</event>
+
+                <event name="visible_changed">
+		        <arg name="visible" type="int"/>
+		</event>
 	</interface>
 
-	<interface name="embedded_shell" version="1">
-		<request name="surface_create">
-			<arg name="surface" type="object" interface="wl_surface" />
-			<arg name="new_shellsurface_id" type="new_id" interface="embedded_shell_surface" />
-			<arg name="anchor" type="uint" />
-			<arg name="margin" type="uint" />
-			<arg name="sort_index" type="uint" />
+        <interface name="embedded_shell" version="1">
+	        <request name="surface_create">
+		        <arg name="surface" type="object" interface="wl_surface"/>
+			<arg name="new_shellsurface_id" type="new_id" interface="embedded_shell_surface"/>
+			<arg name="anchor" type="uint"/>
+			<arg name="margin" type="uint"/>
+			<arg name="sort_index" type="uint"/>
 		</request>
 
-		<enum name="error">
-			<entry name="role" value="0" summary="wl_surface already has a different role" />
+                <enum name="error">
+		        <entry name="role" value="0" summary="wl_surface already has a different role"/>
 		</enum>
 
-		<enum name="anchor_border">
-			<description summary="screen border anchor"> Which screen border the surface will be anchored to </description>
-			<entry name="undefined" value="0" />
-			<entry name="top" value="1" />
-			<entry name="bottom" value="2" />
-			<entry name="left" value="3" />
-			<entry name="right" value="4" />
-			<entry name="center" value="5" />
+                <enum name="anchor_border">
+		        <description summary="screen border anchor"> Which screen border the surface will be anchored to </description>
+			<entry name="undefined" value="0"/>
+			<entry name="top" value="1"/>
+			<entry name="bottom" value="2"/>
+			<entry name="left" value="3"/>
+			<entry name="right" value="4"/>
+			<entry name="center" value="5"/>
 		</enum>
 	</interface>
 
-	<interface name="surface_view" version="1">
-		<request name="set_app_label">
-			<description summary="Set the user-visible application name"/>
-			<arg name="label" type="string" />
+        <interface name="surface_view" version="1">
+	        <request name="set_app_label">
+		        <description summary="Set the user-visible application name"/>
+			<arg name="label" type="string"/>
 		</request>
-		<request name="set_app_icon">
-			<description summary="Set the application icon name"/>
-			<arg name="label" type="string" />
+
+                <request name="set_app_icon">
+		        <description summary="Set the application icon name"/>
+			<arg name="label" type="string"/>
 		</request>
-		<request name="set_label">
-			<arg name="text" type="string" />
+
+                <request name="set_label">
+		        <arg name="text" type="string"/>
 		</request>
-		<request name="set_icon">
-			<description summary="Set the icon name for this view"/>
-			<arg name="text" type="string" />
+
+                <request name="set_icon">
+		        <description summary="Set the icon name for this view"/>
+			<arg name="text" type="string"/>
 		</request>
-		<request name="set_sort_index">
-			<arg name="sort_index" type="uint" />
+
+                <request name="set_sort_index">
+		        <arg name="sort_index" type="uint"/>
 		</request>
-		<event name="selected"></event>
-		<request name="destroy" type="destructor"></request>
+
+                <request name="set_custom_data">
+		        <arg name="custom_data" type="array"/>
+		</request>
+
+                <request name="destroy" type="destructor"/>
+
+                <event name="selected"/>
 	</interface>
 </protocol>

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -37,6 +37,7 @@
 			<arg name="label" type="string" summary="The user-visible label for this particular view"/>
 			<arg name="icon" type="string" summary="The icon name of this particular view"/>
 			<arg name="sort_index" type="uint"/>
+			<arg name="persistentId" type="string" summary="Optional id to identify the views across session boundaries"/>
 			<arg name="custom_data" type="array"/>
 			<arg name="parent_view" type="object" interface="surface_view" allow-null="true"/>
 			<arg name="new_view_id" type="new_id" interface="surface_view"/>

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -1,60 +1,60 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <protocol name="embedded_shell">
-        <copyright>
+	<copyright>
 	FIXME
 	</copyright>
 
-        <interface name="embedded_shell_surface" version="1">
-	        <request name="destroy" type="destructor"/>
+	<interface name="embedded_shell_surface" version="1">
+		<request name="destroy" type="destructor"/>
 
-                <request name="set_anchor">
-		        <arg name="anchor" type="uint"/>
+		<request name="set_anchor">
+			<arg name="anchor" type="uint"/>
 		</request>
 
-                <request name="set_margin">
-		        <arg name="margin" type="int"/>
+		<request name="set_margin">
+			<arg name="margin" type="int"/>
 		</request>
 
-                <request name="set_sort_index">
-		        <arg name="sort_index" type="uint"/>
+		<request name="set_sort_index">
+			<arg name="sort_index" type="uint"/>
 		</request>
 
-                <request name="set_app_id">
-		        <description summary="Set the application ID of the application"/>
+		<request name="set_app_id">
+			<description summary="Set the application ID of the application"/>
 			<arg name="label" type="string"/>
 		</request>
 
-                <request name="set_app_label">
-		        <description summary="Set the user-visible name of the application"/>
+		<request name="set_app_label">
+			<description summary="Set the user-visible name of the application"/>
 			<arg name="label" type="string"/>
 		</request>
 
-                <request name="set_app_icon">
-		        <description summary="Set the icon name of this application"/>
+		<request name="set_app_icon">
+			<description summary="Set the icon name of this application"/>
 			<arg name="icon" type="string"/>
 		</request>
 
-                <request name="set_size">
-		        <description summary="Sets the size of the surface">
-			        Sets the size of the surface in surface-local coordinates. The compositor will display the surface
+		<request name="set_size">
+			<description summary="Sets the size of the surface">
+				Sets the size of the surface in surface-local coordinates. The compositor will display the surface
 				with respect to its anchors.
 
-                                If you pass 0 for either value, the compositor will assign it and inform you of the assignment in the
+				If you pass 0 for either value, the compositor will assign it and inform you of the assignment in the
 				configure event. You must set your anchor to opposite edges in the dimensions you omit.
 			</description>
 			<arg name="width" type="uint"/>
 			<arg name="height" type="uint"/>
 		</request>
 
-                <request name="set_custom_data">
-		        <arg name="custom_data" type="array"/>
+		<request name="set_custom_data">
+			<arg name="custom_data" type="array"/>
 		</request>
 
-                <request name="view_create">
-		        <description summary="create an embedded shell surface_view">
-			        Creates an Embedded Shell Surface.
+		<request name="view_create">
+			<description summary="create an embedded shell surface_view">
+				Creates an Embedded Shell Surface.
 
-                                The app_id identifies the logical application this surface belongs to.
+				The app_id identifies the logical application this surface belongs to.
 				The app_label can be empty at which point the label will be used.
 				The app_icon can be empty at which point the icon will be used.
 			</description>
@@ -69,9 +69,9 @@
 			<arg name="new_view_id" type="new_id" interface="surface_view"/>
 		</request>
 
-                <event name="configure">
-		        <description summary="suggest resize">
-			        The configure event asks the client to resize its surface.
+		<event name="configure">
+			<description summary="suggest resize">
+				The configure event asks the client to resize its surface.
 				The width and height arguments specify the size of the window
 				in surface local coordinates.
 			</description>
@@ -79,26 +79,26 @@
 			<arg name="height" type="int"/>
 		</event>
 
-                <event name="visible_changed">
-		        <arg name="visible" type="int"/>
+		<event name="visible_changed">
+			<arg name="visible" type="int"/>
 		</event>
 	</interface>
 
-        <interface name="embedded_shell" version="1">
-	        <request name="surface_create">
-		        <arg name="surface" type="object" interface="wl_surface"/>
+	<interface name="embedded_shell" version="1">
+		<request name="surface_create">
+			<arg name="surface" type="object" interface="wl_surface"/>
 			<arg name="new_shellsurface_id" type="new_id" interface="embedded_shell_surface"/>
 			<arg name="anchor" type="uint"/>
 			<arg name="margin" type="uint"/>
 			<arg name="sort_index" type="uint"/>
 		</request>
 
-                <enum name="error">
-		        <entry name="role" value="0" summary="wl_surface already has a different role"/>
+		<enum name="error">
+			<entry name="role" value="0" summary="wl_surface already has a different role"/>
 		</enum>
 
-                <enum name="anchor_border">
-		        <description summary="screen border anchor"> Which screen border the surface will be anchored to </description>
+		<enum name="anchor_border">
+			<description summary="screen border anchor"> Which screen border the surface will be anchored to </description>
 			<entry name="undefined" value="0"/>
 			<entry name="top" value="1"/>
 			<entry name="bottom" value="2"/>
@@ -108,36 +108,38 @@
 		</enum>
 	</interface>
 
-        <interface name="surface_view" version="1">
-	        <request name="set_app_label">
-		        <description summary="Set the user-visible application name"/>
+	<interface name="surface_view" version="1">
+		<request name="set_app_label">
+			<description summary="Set the user-visible application name"/>
 			<arg name="label" type="string"/>
 		</request>
 
-                <request name="set_app_icon">
-		        <description summary="Set the application icon name"/>
+		<request name="set_app_icon">
+			<description summary="Set the application icon name"/>
 			<arg name="label" type="string"/>
 		</request>
 
-                <request name="set_label">
-		        <arg name="text" type="string"/>
-		</request>
-
-                <request name="set_icon">
-		        <description summary="Set the icon name for this view"/>
+		<request name="set_label">
 			<arg name="text" type="string"/>
 		</request>
 
-                <request name="set_sort_index">
-		        <arg name="sort_index" type="uint"/>
+		<request name="set_icon">
+			<description summary="Set the icon name for this view"/>
+			<arg name="text" type="string"/>
 		</request>
 
-                <request name="set_custom_data">
-		        <arg name="custom_data" type="array"/>
+		<request name="set_sort_index">
+			<arg name="sort_index" type="uint"/>
 		</request>
 
-                <request name="destroy" type="destructor"/>
+		<request name="set_custom_data">
+			<arg name="custom_data" type="array"/>
+		</request>
 
-                <event name="selected"/>
+		<request name="select"/>
+
+		<request name="destroy" type="destructor"/>
+
+		<event name="selected"/>
 	</interface>
 </protocol>

--- a/protocol/embedded-shell.xml
+++ b/protocol/embedded-shell.xml
@@ -15,25 +15,6 @@
 			<arg name="margin" type="int"/>
 		</request>
 
-		<request name="set_sort_index">
-			<arg name="sort_index" type="uint"/>
-		</request>
-
-		<request name="set_app_id">
-			<description summary="Set the application ID of the application"/>
-			<arg name="label" type="string"/>
-		</request>
-
-		<request name="set_app_label">
-			<description summary="Set the user-visible name of the application"/>
-			<arg name="label" type="string"/>
-		</request>
-
-		<request name="set_app_icon">
-			<description summary="Set the icon name of this application"/>
-			<arg name="icon" type="string"/>
-		</request>
-
 		<request name="set_size">
 			<description summary="Sets the size of the surface">
 				Sets the size of the surface in surface-local coordinates. The compositor will display the surface
@@ -46,26 +27,18 @@
 			<arg name="height" type="uint"/>
 		</request>
 
-		<request name="set_custom_data">
-			<arg name="custom_data" type="array"/>
-		</request>
-
 		<request name="view_create">
 			<description summary="create an embedded shell surface_view">
-				Creates an Embedded Shell Surface.
+				Creates an Embedded Shell Surface View.
 
-				The app_id identifies the logical application this surface belongs to.
-				The app_label can be empty at which point the label will be used.
-				The app_icon can be empty at which point the icon will be used.
+				The parent_view can be empty, indicating that this is a top level view.
 			</description>
 			<arg name="shell_surface" type="object" interface="embedded_shell_surface"/>
-			<arg name="app_id" type="string" summary="The application ID"/>
-			<arg name="app_label" type="string" summary="The user-visible name of the application"/>
-			<arg name="app_icon" type="string" summary="The icon name of the application"/>
 			<arg name="label" type="string" summary="The user-visible label for this particular view"/>
 			<arg name="icon" type="string" summary="The icon name of this particular view"/>
 			<arg name="sort_index" type="uint"/>
 			<arg name="custom_data" type="array"/>
+			<arg name="parent_view" type="object" interface="surface_view" allow-null="true"/>
 			<arg name="new_view_id" type="new_id" interface="surface_view"/>
 		</request>
 
@@ -90,7 +63,6 @@
 			<arg name="new_shellsurface_id" type="new_id" interface="embedded_shell_surface"/>
 			<arg name="anchor" type="uint"/>
 			<arg name="margin" type="uint"/>
-			<arg name="sort_index" type="uint"/>
 		</request>
 
 		<enum name="error">
@@ -109,16 +81,6 @@
 	</interface>
 
 	<interface name="surface_view" version="1">
-		<request name="set_app_label">
-			<description summary="Set the user-visible application name"/>
-			<arg name="label" type="string"/>
-		</request>
-
-		<request name="set_app_icon">
-			<description summary="Set the application icon name"/>
-			<arg name="label" type="string"/>
-		</request>
-
 		<request name="set_label">
 			<arg name="text" type="string"/>
 		</request>

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -190,12 +190,18 @@ bool QuickEmbeddedShellSurface::visible() const
 EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& label,
                                                                 const QString& icon,
                                                                 uint32_t sortIndex,
+                                                                const QString &persistentId,
                                                                 const QVariantMap &customData,
                                                                 EmbeddedShellSurfaceView *parentView)
 {
   if (m_surface) {
-    auto view = m_surface->createView(label, icon, sortIndex, customData, parentView);
-    qCDebug(quickShell) << Q_FUNC_INFO << label << icon << view << sortIndex << customData << parentView;
+    auto view = m_surface->createView(label,
+                                      icon,
+                                      sortIndex,
+                                      persistentId,
+                                      customData,
+                                      parentView);
+    qCDebug(quickShell) << Q_FUNC_INFO << view << label << icon << sortIndex << persistentId << customData << parentView;
     return view;
   } else {
     qCDebug(quickShell) << Q_FUNC_INFO << "Surface has not been created yet!";

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -190,7 +190,7 @@ bool QuickEmbeddedShellSurface::visible() const
 EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& label,
                                                                 const QString& icon,
                                                                 uint32_t sortIndex,
-                                                                const QVariant &customData,
+                                                                const QVariantMap &customData,
                                                                 EmbeddedShellSurfaceView *parentView)
 {
   if (m_surface) {

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -29,7 +29,7 @@ void QuickEmbeddedShellSurface::classBegin()
 void QuickEmbeddedShellSurface::componentComplete()
 {
   if (!m_window) {
-    qCCritical(quickShell) << __PRETTY_FUNCTION__ << "called without a window set; aborting component completion.";
+    qCCritical(quickShell) << Q_FUNC_INFO << "called without a window set; aborting component completion.";
     return;
   }
 
@@ -59,25 +59,26 @@ void QuickEmbeddedShellSurface::componentComplete()
   {
     m_surface = surface;
     if (m_size.isValid()) {
-      m_surface->sendSize(m_size);
+      m_surface->setSize(m_size);
     }
-    m_surface->sendAnchor(m_anchor);
-    m_surface->sendMargin(m_margin);
-    m_surface->sendSortIndex(m_sortIndex);
-    m_surface->sendAppId(m_appId);
-    m_surface->sendAppLabel(m_appLabel);
-    m_surface->sendAppIcon(m_appIcon);
+    m_surface->setAnchor(m_anchor);
+    m_surface->setMargin(m_margin);
+    m_surface->setSortIndex(m_sortIndex);
+    m_surface->setCustomData(m_customData);
+    m_surface->setAppId(m_appId);
+    m_surface->setAppLabel(m_appLabel);
+    m_surface->setAppIcon(m_appIcon);
 
     connect(m_surface, &EmbeddedShellSurface::visibleChanged, this, &QuickEmbeddedShellSurface::visibleChanged);
 
-    if (m_surface->getVisible())
+    if (m_surface->visible())
     {
       emit visibleChanged(true);
     }
 
     m_componentComplete = true;
-    Q_EMIT completedChanged(m_componentComplete);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_surface << m_anchor << m_margin << m_size << m_sortIndex;
+    emit completedChanged(m_componentComplete);
+    qCDebug(quickShell) << Q_FUNC_INFO << m_surface << m_anchor << m_margin << m_size << m_sortIndex;
   }
 }
 
@@ -90,7 +91,7 @@ void QuickEmbeddedShellSurface::setWindow(QWindow *window)
 {
   if (!m_window && window) {
     m_window = window;
-    Q_EMIT windowChanged(window);
+    emit windowChanged(window);
   } else {
     qCWarning(quickShell) << "Invalid window assignment from" << m_window << "to" << window << "!";
   }
@@ -107,13 +108,13 @@ void QuickEmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << m_anchor << "->" << newAnchor;
+  qCDebug(quickShell) << Q_FUNC_INFO << m_anchor << "->" << newAnchor;
 
   m_anchor = newAnchor;
-  Q_EMIT anchorChanged(newAnchor);
+  emit anchorChanged(newAnchor);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendAnchor(m_anchor);
+    m_surface->setAnchor(m_anchor);
   }
 }
 
@@ -131,13 +132,13 @@ void QuickEmbeddedShellSurface::setImplicitWidth(int implicitWidth)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitWidth;
+  qCDebug(quickShell) << Q_FUNC_INFO << implicitWidth;
 
   m_size = newSize;
-  Q_EMIT implicitWidthChanged(implicitWidth);
+  emit implicitWidthChanged(implicitWidth);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendSize(m_size);
+    m_surface->setSize(m_size);
   }
 }
 
@@ -153,13 +154,13 @@ void QuickEmbeddedShellSurface::setImplicitHeight(int implicitHeight)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << implicitHeight;
+  qCDebug(quickShell) << Q_FUNC_INFO << implicitHeight;
 
   m_size = newSize;
-  Q_EMIT implicitHeightChanged(implicitHeight);
+  emit implicitHeightChanged(implicitHeight);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendSize(m_size);
+    m_surface->setSize(m_size);
   }
 }
 
@@ -174,13 +175,13 @@ void QuickEmbeddedShellSurface::setMargin(int newMargin)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << newMargin;
+  qCDebug(quickShell) << Q_FUNC_INFO << newMargin;
 
   m_margin = newMargin;
-  Q_EMIT marginChanged(newMargin);
+  emit marginChanged(newMargin);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendMargin(m_margin);
+    m_surface->setMargin(m_margin);
   }
 }
 
@@ -195,13 +196,34 @@ void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << sortIndex;
+  qCDebug(quickShell) << Q_FUNC_INFO << sortIndex;
 
   m_sortIndex = sortIndex;
-  Q_EMIT sortIndexChanged(sortIndex);
+  emit sortIndexChanged(sortIndex);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendSortIndex(m_sortIndex);
+    m_surface->setSortIndex(m_sortIndex);
+  }
+}
+
+QVariant QuickEmbeddedShellSurface::customData() const
+{
+  return m_customData;
+}
+
+void QuickEmbeddedShellSurface::setCustomData(const QVariant &customData)
+{
+  if (m_customData == customData) {
+    return;
+  }
+
+  qCDebug(quickShell) << Q_FUNC_INFO << customData;
+
+  m_customData = customData;
+  emit customDataChanged(customData);
+
+  if (m_componentComplete && m_surface) {
+    m_surface->setCustomData(m_customData);
   }
 }
 
@@ -213,7 +235,7 @@ QString QuickEmbeddedShellSurface::appId() const
 void QuickEmbeddedShellSurface::setAppId(const QString &appId)
 {
   if (m_componentComplete) {
-    qCWarning(quickShell) << __PRETTY_FUNCTION__ << "AppId cannot be changed after the component has been completed!";
+    qCWarning(quickShell) << Q_FUNC_INFO << "AppId cannot be changed after the component has been completed!";
     return;
   }
 
@@ -221,10 +243,10 @@ void QuickEmbeddedShellSurface::setAppId(const QString &appId)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId;
+  qCDebug(quickShell) << Q_FUNC_INFO << appId;
 
   m_appId = appId;
-  Q_EMIT appIdChanged(appId);
+  emit appIdChanged(appId);
 }
 
 QString QuickEmbeddedShellSurface::appLabel() const
@@ -238,13 +260,13 @@ void QuickEmbeddedShellSurface::setAppLabel(const QString &appLabel)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appLabel;
+  qCDebug(quickShell) << Q_FUNC_INFO << appLabel;
 
   m_appLabel = appLabel;
-  Q_EMIT appLabelChanged(appLabel);
+  emit appLabelChanged(appLabel);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendAppLabel(m_appLabel);
+    m_surface->setAppLabel(m_appLabel);
   }
 }
 
@@ -259,13 +281,13 @@ void QuickEmbeddedShellSurface::setAppIcon(const QString &appIcon)
     return;
   }
 
-  qCDebug(quickShell) << __PRETTY_FUNCTION__ << appIcon;
+  qCDebug(quickShell) << Q_FUNC_INFO << appIcon;
 
   m_appIcon = appIcon;
-  Q_EMIT appIconChanged(appIcon);
+  emit appIconChanged(appIcon);
 
   if (m_componentComplete && m_surface) {
-    m_surface->sendAppIcon(m_appIcon);
+    m_surface->setAppIcon(m_appIcon);
   }
 }
 
@@ -276,20 +298,20 @@ bool QuickEmbeddedShellSurface::completed() const
 
 bool QuickEmbeddedShellSurface::visible() const
 {
-  return m_surface && m_surface->getVisible();
+  return m_surface && m_surface->visible();
 }
 
 EmbeddedShellSurfaceView *QuickEmbeddedShellSurface::createView(const QString &appId,
                                                                 const QString &appLabel,
                                                                 const QString &label,
-                                                                unsigned int sort_index)
+                                                                unsigned int sortIndex)
 {
   if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, label, sort_index);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << view << label;
+    auto view = m_surface->createView(appId, appLabel, label, sortIndex);
+    qCDebug(quickShell) << Q_FUNC_INFO << appId << appLabel << view << label;
     return view;
   } else {
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    qCDebug(quickShell) << Q_FUNC_INFO << "Surface has not been created yet!";
     return nullptr;
   }
 }
@@ -299,14 +321,15 @@ EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& a
                                                                 const QString& appIcon,
                                                                 const QString& label,
                                                                 const QString& icon,
-                                                                uint32_t sort_index)
+                                                                uint32_t sortIndex,
+                                                                const QVariant &customData)
 {
   if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sort_index);
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << appId << appLabel << appIcon << label << icon << view << sort_index;
+    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sortIndex, customData);
+    qCDebug(quickShell) << Q_FUNC_INFO << appId << appLabel << appIcon << label << icon << view << sortIndex << customData;
     return view;
   } else {
-    qCDebug(quickShell) << __PRETTY_FUNCTION__ << "Surface has not been created yet!";
+    qCDebug(quickShell) << Q_FUNC_INFO << "Surface has not been created yet!";
     return nullptr;
   }
 }

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -73,11 +73,11 @@ void QuickEmbeddedShellSurface::componentComplete()
 
     if (m_surface->visible())
     {
-      emit visibleChanged(true);
+      emit visibleChanged();
     }
 
     m_componentComplete = true;
-    emit completedChanged(m_componentComplete);
+    emit completedChanged();
     qCDebug(quickShell) << Q_FUNC_INFO << m_surface << m_anchor << m_margin << m_size << m_sortIndex;
   }
 }
@@ -91,7 +91,7 @@ void QuickEmbeddedShellSurface::setWindow(QWindow *window)
 {
   if (!m_window && window) {
     m_window = window;
-    emit windowChanged(window);
+    emit windowChanged();
   } else {
     qCWarning(quickShell) << "Invalid window assignment from" << m_window << "to" << window << "!";
   }
@@ -111,7 +111,7 @@ void QuickEmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
   qCDebug(quickShell) << Q_FUNC_INFO << m_anchor << "->" << newAnchor;
 
   m_anchor = newAnchor;
-  emit anchorChanged(newAnchor);
+  emit anchorChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setAnchor(m_anchor);
@@ -135,7 +135,7 @@ void QuickEmbeddedShellSurface::setImplicitWidth(int implicitWidth)
   qCDebug(quickShell) << Q_FUNC_INFO << implicitWidth;
 
   m_size = newSize;
-  emit implicitWidthChanged(implicitWidth);
+  emit implicitWidthChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setSize(m_size);
@@ -157,7 +157,7 @@ void QuickEmbeddedShellSurface::setImplicitHeight(int implicitHeight)
   qCDebug(quickShell) << Q_FUNC_INFO << implicitHeight;
 
   m_size = newSize;
-  emit implicitHeightChanged(implicitHeight);
+  emit implicitHeightChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setSize(m_size);
@@ -178,7 +178,7 @@ void QuickEmbeddedShellSurface::setMargin(int newMargin)
   qCDebug(quickShell) << Q_FUNC_INFO << newMargin;
 
   m_margin = newMargin;
-  emit marginChanged(newMargin);
+  emit marginChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setMargin(m_margin);
@@ -199,7 +199,7 @@ void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
   qCDebug(quickShell) << Q_FUNC_INFO << sortIndex;
 
   m_sortIndex = sortIndex;
-  emit sortIndexChanged(sortIndex);
+  emit sortIndexChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setSortIndex(m_sortIndex);
@@ -220,7 +220,7 @@ void QuickEmbeddedShellSurface::setCustomData(const QVariant &customData)
   qCDebug(quickShell) << Q_FUNC_INFO << customData;
 
   m_customData = customData;
-  emit customDataChanged(customData);
+  emit customDataChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setCustomData(m_customData);
@@ -246,7 +246,7 @@ void QuickEmbeddedShellSurface::setAppId(const QString &appId)
   qCDebug(quickShell) << Q_FUNC_INFO << appId;
 
   m_appId = appId;
-  emit appIdChanged(appId);
+  emit appIdChanged();
 }
 
 QString QuickEmbeddedShellSurface::appLabel() const
@@ -263,7 +263,7 @@ void QuickEmbeddedShellSurface::setAppLabel(const QString &appLabel)
   qCDebug(quickShell) << Q_FUNC_INFO << appLabel;
 
   m_appLabel = appLabel;
-  emit appLabelChanged(appLabel);
+  emit appLabelChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setAppLabel(m_appLabel);
@@ -284,7 +284,7 @@ void QuickEmbeddedShellSurface::setAppIcon(const QString &appIcon)
   qCDebug(quickShell) << Q_FUNC_INFO << appIcon;
 
   m_appIcon = appIcon;
-  emit appIconChanged(appIcon);
+  emit appIconChanged();
 
   if (m_componentComplete && m_surface) {
     m_surface->setAppIcon(m_appIcon);

--- a/quickembeddedshellwindow/quickembeddedshellsurface.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.cpp
@@ -16,7 +16,6 @@ QuickEmbeddedShellSurface::QuickEmbeddedShellSurface(QObject *parent)
     , m_anchor(EmbeddedShellTypes::Anchor::Undefined)
     , m_surface(nullptr)
     , m_margin(-1)
-    , m_sortIndex(0)
     , m_componentComplete(false)
     , m_visible(false)
 {
@@ -63,11 +62,6 @@ void QuickEmbeddedShellSurface::componentComplete()
     }
     m_surface->setAnchor(m_anchor);
     m_surface->setMargin(m_margin);
-    m_surface->setSortIndex(m_sortIndex);
-    m_surface->setCustomData(m_customData);
-    m_surface->setAppId(m_appId);
-    m_surface->setAppLabel(m_appLabel);
-    m_surface->setAppIcon(m_appIcon);
 
     connect(m_surface, &EmbeddedShellSurface::visibleChanged, this, &QuickEmbeddedShellSurface::visibleChanged);
 
@@ -78,22 +72,7 @@ void QuickEmbeddedShellSurface::componentComplete()
 
     m_componentComplete = true;
     emit completedChanged();
-    qCDebug(quickShell) << Q_FUNC_INFO << m_surface << m_anchor << m_margin << m_size << m_sortIndex;
-  }
-}
-
-QWindow *QuickEmbeddedShellSurface::window() const
-{
-  return m_window;
-}
-
-void QuickEmbeddedShellSurface::setWindow(QWindow *window)
-{
-  if (!m_window && window) {
-    m_window = window;
-    emit windowChanged();
-  } else {
-    qCWarning(quickShell) << "Invalid window assignment from" << m_window << "to" << window << "!";
+    qCDebug(quickShell) << Q_FUNC_INFO << m_surface << m_anchor << m_margin << m_size;
   }
 }
 
@@ -118,7 +97,20 @@ void QuickEmbeddedShellSurface::setAnchor(EmbeddedShellTypes::Anchor newAnchor)
   }
 }
 
+QWindow *QuickEmbeddedShellSurface::window() const
+{
+  return m_window;
+}
 
+void QuickEmbeddedShellSurface::setWindow(QWindow *window)
+{
+  if (!m_window && window) {
+    m_window = window;
+    emit windowChanged();
+  } else {
+    qCWarning(quickShell) << "Invalid window assignment from" << m_window << "to" << window << "!";
+  }
+}
 
 int QuickEmbeddedShellSurface::implicitWidth() const
 {
@@ -185,112 +177,6 @@ void QuickEmbeddedShellSurface::setMargin(int newMargin)
   }
 }
 
-unsigned int QuickEmbeddedShellSurface::sortIndex() const
-{
-  return m_sortIndex;
-}
-
-void QuickEmbeddedShellSurface::setSortIndex(unsigned int sortIndex)
-{
-  if (m_sortIndex == sortIndex) {
-    return;
-  }
-
-  qCDebug(quickShell) << Q_FUNC_INFO << sortIndex;
-
-  m_sortIndex = sortIndex;
-  emit sortIndexChanged();
-
-  if (m_componentComplete && m_surface) {
-    m_surface->setSortIndex(m_sortIndex);
-  }
-}
-
-QVariant QuickEmbeddedShellSurface::customData() const
-{
-  return m_customData;
-}
-
-void QuickEmbeddedShellSurface::setCustomData(const QVariant &customData)
-{
-  if (m_customData == customData) {
-    return;
-  }
-
-  qCDebug(quickShell) << Q_FUNC_INFO << customData;
-
-  m_customData = customData;
-  emit customDataChanged();
-
-  if (m_componentComplete && m_surface) {
-    m_surface->setCustomData(m_customData);
-  }
-}
-
-QString QuickEmbeddedShellSurface::appId() const
-{
-  return m_appId;
-}
-
-void QuickEmbeddedShellSurface::setAppId(const QString &appId)
-{
-  if (m_componentComplete) {
-    qCWarning(quickShell) << Q_FUNC_INFO << "AppId cannot be changed after the component has been completed!";
-    return;
-  }
-
-  if (m_appId == appId) {
-    return;
-  }
-
-  qCDebug(quickShell) << Q_FUNC_INFO << appId;
-
-  m_appId = appId;
-  emit appIdChanged();
-}
-
-QString QuickEmbeddedShellSurface::appLabel() const
-{
-  return m_appLabel;
-}
-
-void QuickEmbeddedShellSurface::setAppLabel(const QString &appLabel)
-{
-  if (m_appLabel == appLabel) {
-    return;
-  }
-
-  qCDebug(quickShell) << Q_FUNC_INFO << appLabel;
-
-  m_appLabel = appLabel;
-  emit appLabelChanged();
-
-  if (m_componentComplete && m_surface) {
-    m_surface->setAppLabel(m_appLabel);
-  }
-}
-
-QString QuickEmbeddedShellSurface::appIcon() const
-{
-  return m_appIcon;
-}
-
-void QuickEmbeddedShellSurface::setAppIcon(const QString &appIcon)
-{
-  if (m_appIcon == appIcon) {
-    return;
-  }
-
-  qCDebug(quickShell) << Q_FUNC_INFO << appIcon;
-
-  m_appIcon = appIcon;
-  emit appIconChanged();
-
-  if (m_componentComplete && m_surface) {
-    m_surface->setAppIcon(m_appIcon);
-  }
-}
-
 bool QuickEmbeddedShellSurface::completed() const
 {
   return m_componentComplete;
@@ -301,32 +187,15 @@ bool QuickEmbeddedShellSurface::visible() const
   return m_surface && m_surface->visible();
 }
 
-EmbeddedShellSurfaceView *QuickEmbeddedShellSurface::createView(const QString &appId,
-                                                                const QString &appLabel,
-                                                                const QString &label,
-                                                                unsigned int sortIndex)
-{
-  if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, label, sortIndex);
-    qCDebug(quickShell) << Q_FUNC_INFO << appId << appLabel << view << label;
-    return view;
-  } else {
-    qCDebug(quickShell) << Q_FUNC_INFO << "Surface has not been created yet!";
-    return nullptr;
-  }
-}
-
-EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& appId,
-                                                                const QString& appLabel,
-                                                                const QString& appIcon,
-                                                                const QString& label,
+EmbeddedShellSurfaceView* QuickEmbeddedShellSurface::createView(const QString& label,
                                                                 const QString& icon,
                                                                 uint32_t sortIndex,
-                                                                const QVariant &customData)
+                                                                const QVariant &customData,
+                                                                EmbeddedShellSurfaceView *parentView)
 {
   if (m_surface) {
-    auto view = m_surface->createView(appId, appLabel, appIcon, label, icon, sortIndex, customData);
-    qCDebug(quickShell) << Q_FUNC_INFO << appId << appLabel << appIcon << label << icon << view << sortIndex << customData;
+    auto view = m_surface->createView(label, icon, sortIndex, customData, parentView);
+    qCDebug(quickShell) << Q_FUNC_INFO << label << icon << view << sortIndex << customData << parentView;
     return view;
   } else {
     qCDebug(quickShell) << Q_FUNC_INFO << "Surface has not been created yet!";

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -90,18 +90,18 @@ public:
                                                    const QVariant &customData);
 
 signals:
-  void windowChanged(QWindow *window);
-  void implicitWidthChanged(int implicitWidth);
-  void implicitHeightChanged(int implicitHeight);
-  void anchorChanged(EmbeddedShellTypes::Anchor anchor);
-  void marginChanged(int margin);
-  void sortIndexChanged(unsigned int sortIndex);
-  void customDataChanged(const QVariant &customData);
-  void appIdChanged(const QString &appId);
-  void appLabelChanged(const QString &appLabel);
-  void appIconChanged(const QString &appIcon);
-  void completedChanged(bool completed);
-  void visibleChanged(bool visible);
+  void windowChanged();
+  void implicitWidthChanged();
+  void implicitHeightChanged();
+  void anchorChanged();
+  void marginChanged();
+  void sortIndexChanged();
+  void customDataChanged();
+  void appIdChanged();
+  void appLabelChanged();
+  void appIconChanged();
+  void completedChanged();
+  void visibleChanged();
 
 private:
   QWindow *m_window;

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef QUICKEMBEDDEDSHELLSURFACE_H
-#define QUICKEMBEDDEDSHELLSURFACE_H
+#pragma once
 
 #include "embeddedplatform.h"
 #include "quickembeddedshellwindow_global.h"
@@ -33,6 +32,7 @@ public:
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
   Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
   Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
   Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
@@ -60,6 +60,9 @@ public:
   unsigned int sortIndex() const;
   void setSortIndex(unsigned int sortIndex);
 
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
+
   QString appId() const;
   void setAppId(const QString &appId);
 
@@ -70,19 +73,21 @@ public:
   void setAppIcon(const QString &appIcon);
 
   bool completed() const;
+
   bool visible() const;
 
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
                                                    const QString &appLabel,
                                                    const QString &label,
-                                                   unsigned int sort_index);
+                                                   unsigned int sortIndex);
 
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
                                                    const QString &appLabel,
                                                    const QString &appIcon,
                                                    const QString &label,
                                                    const QString &icon,
-                                                   uint32_t sort_index);
+                                                   uint32_t sortIndex,
+                                                   const QVariant &customData);
 
 signals:
   void windowChanged(QWindow *window);
@@ -91,6 +96,7 @@ signals:
   void anchorChanged(EmbeddedShellTypes::Anchor anchor);
   void marginChanged(int margin);
   void sortIndexChanged(unsigned int sortIndex);
+  void customDataChanged(const QVariant &customData);
   void appIdChanged(const QString &appId);
   void appLabelChanged(const QString &appLabel);
   void appIconChanged(const QString &appIcon);
@@ -104,11 +110,10 @@ private:
   EmbeddedShellSurface *m_surface;
   int m_margin;
   unsigned int m_sortIndex;
+  QVariant m_customData;
   QString m_appId;
   QString m_appLabel;
   QString m_appIcon;
   bool m_componentComplete;
   bool m_visible;
 };
-
-#endif // QUICKEMBEDDEDSHELLSURFACE_H

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -31,11 +31,6 @@ public:
   Q_PROPERTY(int implicitHeight READ implicitHeight WRITE setImplicitHeight NOTIFY implicitHeightChanged)
   Q_PROPERTY(EmbeddedShellTypes::Anchor anchor READ anchor WRITE setAnchor NOTIFY anchorChanged)
   Q_PROPERTY(int margin READ margin WRITE setMargin NOTIFY marginChanged)
-  Q_PROPERTY(unsigned int sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
-  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
   Q_PROPERTY(bool completed READ completed NOTIFY completedChanged)
   Q_PROPERTY(bool visible READ visible NOTIFY visibleChanged)
 
@@ -57,37 +52,15 @@ public:
   int margin() const;
   void setMargin(int newMargin);
 
-  unsigned int sortIndex() const;
-  void setSortIndex(unsigned int sortIndex);
-
-  QVariant customData() const;
-  void setCustomData(const QVariant &customData);
-
-  QString appId() const;
-  void setAppId(const QString &appId);
-
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
-
   bool completed() const;
 
   bool visible() const;
 
-  Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
-                                                   const QString &appLabel,
-                                                   const QString &label,
-                                                   unsigned int sortIndex);
-
-  Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &appId,
-                                                   const QString &appLabel,
-                                                   const QString &appIcon,
-                                                   const QString &label,
+  Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &label,
                                                    const QString &icon,
                                                    uint32_t sortIndex,
-                                                   const QVariant &customData);
+                                                   const QVariant &customData = QVariant(),
+                                                   EmbeddedShellSurfaceView *parentView = nullptr);
 
 signals:
   void windowChanged();
@@ -95,11 +68,6 @@ signals:
   void implicitHeightChanged();
   void anchorChanged();
   void marginChanged();
-  void sortIndexChanged();
-  void customDataChanged();
-  void appIdChanged();
-  void appLabelChanged();
-  void appIconChanged();
   void completedChanged();
   void visibleChanged();
 
@@ -109,11 +77,6 @@ private:
   EmbeddedShellTypes::Anchor m_anchor = EmbeddedShellTypes::Anchor::Undefined;
   EmbeddedShellSurface *m_surface;
   int m_margin;
-  unsigned int m_sortIndex;
-  QVariant m_customData;
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
   bool m_componentComplete;
   bool m_visible;
 };

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -59,6 +59,7 @@ public:
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &label,
                                                    const QString &icon,
                                                    uint32_t sortIndex,
+                                                   const QString &persistentId = QString(),
                                                    const QVariantMap &customData = QVariantMap(),
                                                    EmbeddedShellSurfaceView *parentView = nullptr);
 

--- a/quickembeddedshellwindow/quickembeddedshellsurface.h
+++ b/quickembeddedshellwindow/quickembeddedshellsurface.h
@@ -59,7 +59,7 @@ public:
   Q_INVOKABLE EmbeddedShellSurfaceView *createView(const QString &label,
                                                    const QString &icon,
                                                    uint32_t sortIndex,
-                                                   const QVariant &customData = QVariant(),
+                                                   const QVariantMap &customData = QVariantMap(),
                                                    EmbeddedShellSurfaceView *parentView = nullptr);
 
 signals:

--- a/quickembeddedshellwindow/quickembeddedshelltypes.h
+++ b/quickembeddedshellwindow/quickembeddedshelltypes.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef QUICKEMBEDDEDSHELLTYPES_H
-#define QUICKEMBEDDEDSHELLTYPES_H
+#pragma once
 
 #include "embeddedplatform.h"
 #include "embeddedshellsurface.h"
@@ -31,5 +30,3 @@ struct EmbeddedPlatformForeign
   QML_FOREIGN(EmbeddedPlatform)
   QML_NAMED_ELEMENT(Platform)
 };
-
-#endif // QUICKEMBEDDEDSHELLTYPES_H

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -32,7 +32,7 @@ void QuickEmbeddedShellView::setSurface(QuickEmbeddedShellSurface *surface)
 {
   if (!m_surface && surface) {
     m_surface = surface;
-    emit surfaceChanged(surface);
+    emit surfaceChanged();
   }
 }
 
@@ -45,7 +45,7 @@ void QuickEmbeddedShellView::setSelected(bool selected)
 {
   if (m_selected != selected) {
     m_selected = selected;
-    emit selectedChanged(selected);
+    emit selectedChanged();
   }
 }
 
@@ -55,12 +55,13 @@ void QuickEmbeddedShellView::createView()
   Q_ASSERT(view);
 
   connect(view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::setSelected);
-  connect(this, &QuickEmbeddedShellView::appLabelChanged, view, &EmbeddedShellSurfaceView::setAppLabel);
-  connect(this, &QuickEmbeddedShellView::appIconChanged, view, &EmbeddedShellSurfaceView::setAppIcon);
-  connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);
-  connect(this, &QuickEmbeddedShellView::iconChanged, view, &EmbeddedShellSurfaceView::setIcon);
-  connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, &EmbeddedShellSurfaceView::setSortIndex);
-  connect(this, &QuickEmbeddedShellView::customDataChanged, view, &EmbeddedShellSurfaceView::setCustomData);
+  connect(this, &QuickEmbeddedShellView::appLabelChanged, view, [this, view]() { view->setAppLabel(appLabel()); });
+  connect(this, &QuickEmbeddedShellView::appIconChanged, view, [this, view]() { view->setAppIcon(appIcon()); });
+  connect(this, &QuickEmbeddedShellView::labelChanged, view, [this, view]() { view->setLabel(label()); });
+  connect(this, &QuickEmbeddedShellView::iconChanged, view, [this, view]() { view->setIcon(icon()); });
+  connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, [this, view]() { view->setSortIndex(sortIndex()); });
+  connect(this, &QuickEmbeddedShellView::customDataChanged, view, [this, view]() { view->setCustomData(customData()); });
+  connect(this, &QuickEmbeddedShellView::select, view, &EmbeddedShellSurfaceView::select);
   connect(this, &QObject::destroyed, view, &QObject::deleteLater);
 
   m_completed = true;
@@ -80,7 +81,7 @@ void QuickEmbeddedShellView::setAppId(const QString &appId)
 
   if (m_appId != appId) {
     m_appId = appId;
-    emit appIdChanged(appId);
+    emit appIdChanged();
   }
 }
 
@@ -93,7 +94,7 @@ void QuickEmbeddedShellView::setAppLabel(const QString &appLabel)
 {
   if (m_appLabel != appLabel) {
     m_appLabel = appLabel;
-    emit appLabelChanged(appLabel);
+    emit appLabelChanged();
   }
 }
 
@@ -106,7 +107,7 @@ void QuickEmbeddedShellView::setAppIcon(const QString &appIcon)
 {
   if (m_appIcon != appIcon) {
     m_appIcon = appIcon;
-    emit appIconChanged(appIcon);
+    emit appIconChanged();
   }
 }
 
@@ -119,7 +120,7 @@ void QuickEmbeddedShellView::setLabel(const QString &label)
 {
   if (m_label != label) {
     m_label = label;
-    emit labelChanged(label);
+    emit labelChanged();
   }
 }
 
@@ -132,7 +133,7 @@ void QuickEmbeddedShellView::setIcon(const QString &icon)
 {
   if (m_icon != icon) {
     m_icon = icon;
-    emit iconChanged(icon);
+    emit iconChanged();
   }
 }
 
@@ -145,7 +146,7 @@ void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
 {
   if (m_sortIndex != sortIndex) {
     m_sortIndex = sortIndex;
-    emit sortIndexChanged(sortIndex);
+    emit sortIndexChanged();
   }
 }
 
@@ -158,6 +159,6 @@ void QuickEmbeddedShellView::setCustomData(const QVariant &customData)
 {
   if (m_customData != customData) {
     m_customData = customData;
-    emit customDataChanged(customData);
+    emit customDataChanged();
   }
 }

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -32,7 +32,7 @@ void QuickEmbeddedShellView::setSurface(QuickEmbeddedShellSurface *surface)
 {
   if (!m_surface && surface) {
     m_surface = surface;
-    Q_EMIT surfaceChanged(surface);
+    emit surfaceChanged(surface);
   }
 }
 
@@ -45,13 +45,13 @@ void QuickEmbeddedShellView::setSelected(bool selected)
 {
   if (m_selected != selected) {
     m_selected = selected;
-    Q_EMIT selectedChanged(selected);
+    emit selectedChanged(selected);
   }
 }
 
 void QuickEmbeddedShellView::createView()
 {
-  auto view = m_surface->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex);
+  auto view = m_surface->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex, m_customData);
   Q_ASSERT(view);
 
   connect(view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::setSelected);
@@ -60,6 +60,7 @@ void QuickEmbeddedShellView::createView()
   connect(this, &QuickEmbeddedShellView::labelChanged, view, &EmbeddedShellSurfaceView::setLabel);
   connect(this, &QuickEmbeddedShellView::iconChanged, view, &EmbeddedShellSurfaceView::setIcon);
   connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, &EmbeddedShellSurfaceView::setSortIndex);
+  connect(this, &QuickEmbeddedShellView::customDataChanged, view, &EmbeddedShellSurfaceView::setCustomData);
   connect(this, &QObject::destroyed, view, &QObject::deleteLater);
 
   m_completed = true;
@@ -73,13 +74,13 @@ QString QuickEmbeddedShellView::appId() const
 void QuickEmbeddedShellView::setAppId(const QString &appId)
 {
   if (m_completed) {
-    qCWarning(quickShell) << __PRETTY_FUNCTION__ << "AppId cannot be changed after the component has been completed!";
+    qCWarning(quickShell) << Q_FUNC_INFO << "AppId cannot be changed after the component has been completed!";
     return;
   }
 
   if (m_appId != appId) {
     m_appId = appId;
-    Q_EMIT appIdChanged(appId);
+    emit appIdChanged(appId);
   }
 }
 
@@ -92,7 +93,7 @@ void QuickEmbeddedShellView::setAppLabel(const QString &appLabel)
 {
   if (m_appLabel != appLabel) {
     m_appLabel = appLabel;
-    Q_EMIT appLabelChanged(appLabel);
+    emit appLabelChanged(appLabel);
   }
 }
 
@@ -105,7 +106,7 @@ void QuickEmbeddedShellView::setAppIcon(const QString &appIcon)
 {
   if (m_appIcon != appIcon) {
     m_appIcon = appIcon;
-    Q_EMIT appIconChanged(appIcon);
+    emit appIconChanged(appIcon);
   }
 }
 
@@ -118,7 +119,7 @@ void QuickEmbeddedShellView::setLabel(const QString &label)
 {
   if (m_label != label) {
     m_label = label;
-    Q_EMIT labelChanged(label);
+    emit labelChanged(label);
   }
 }
 
@@ -131,7 +132,7 @@ void QuickEmbeddedShellView::setIcon(const QString &icon)
 {
   if (m_icon != icon) {
     m_icon = icon;
-    Q_EMIT iconChanged(icon);
+    emit iconChanged(icon);
   }
 }
 
@@ -144,6 +145,19 @@ void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
 {
   if (m_sortIndex != sortIndex) {
     m_sortIndex = sortIndex;
-    Q_EMIT sortIndexChanged(sortIndex);
+    emit sortIndexChanged(sortIndex);
+  }
+}
+
+QVariant QuickEmbeddedShellView::customData() const
+{
+  return m_customData;
+}
+
+void QuickEmbeddedShellView::setCustomData(const QVariant &customData)
+{
+  if (m_customData != customData) {
+    m_customData = customData;
+    emit customDataChanged(customData);
   }
 }

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -5,6 +5,9 @@ QuickEmbeddedShellView::QuickEmbeddedShellView(QQuickItem *parent)
     : QQuickItem(parent)
     , m_surface(nullptr)
     , m_selected(false)
+    , m_topLevel(false)
+    , m_view(nullptr)
+    , m_parentView(nullptr)
     , m_sortIndex(0)
     , m_completed(false)
 {
@@ -41,7 +44,13 @@ bool QuickEmbeddedShellView::selected() const
   return m_selected;
 }
 
-void QuickEmbeddedShellView::setSelected(bool selected)
+bool QuickEmbeddedShellView::topLevel() const
+{
+  return m_topLevel;
+}
+
+
+void QuickEmbeddedShellView::updateSelected(bool selected)
 {
   if (m_selected != selected) {
     m_selected = selected;
@@ -49,66 +58,17 @@ void QuickEmbeddedShellView::setSelected(bool selected)
   }
 }
 
-void QuickEmbeddedShellView::createView()
+void QuickEmbeddedShellView::updateTopLevel(bool topLevel)
 {
-  auto view = m_surface->createView(m_appId, m_appLabel, m_appIcon, m_label, m_icon, m_sortIndex, m_customData);
-  Q_ASSERT(view);
-
-  connect(view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::setSelected);
-  connect(this, &QuickEmbeddedShellView::appLabelChanged, view, [this, view]() { view->setAppLabel(appLabel()); });
-  connect(this, &QuickEmbeddedShellView::appIconChanged, view, [this, view]() { view->setAppIcon(appIcon()); });
-  connect(this, &QuickEmbeddedShellView::labelChanged, view, [this, view]() { view->setLabel(label()); });
-  connect(this, &QuickEmbeddedShellView::iconChanged, view, [this, view]() { view->setIcon(icon()); });
-  connect(this, &QuickEmbeddedShellView::sortIndexChanged, view, [this, view]() { view->setSortIndex(sortIndex()); });
-  connect(this, &QuickEmbeddedShellView::customDataChanged, view, [this, view]() { view->setCustomData(customData()); });
-  connect(this, &QuickEmbeddedShellView::select, view, &EmbeddedShellSurfaceView::select);
-  connect(this, &QObject::destroyed, view, &QObject::deleteLater);
-
-  m_completed = true;
-}
-
-QString QuickEmbeddedShellView::appId() const
-{
-  return m_appId;
-}
-
-void QuickEmbeddedShellView::setAppId(const QString &appId)
-{
-  if (m_completed) {
-    qCWarning(quickShell) << Q_FUNC_INFO << "AppId cannot be changed after the component has been completed!";
-    return;
-  }
-
-  if (m_appId != appId) {
-    m_appId = appId;
-    emit appIdChanged();
+  if (m_topLevel != topLevel) {
+    m_topLevel = topLevel;
+    emit topLevelChanged();
   }
 }
 
-QString QuickEmbeddedShellView::appLabel() const
+EmbeddedShellSurfaceView *QuickEmbeddedShellView::view() const
 {
-  return m_appLabel;
-}
-
-void QuickEmbeddedShellView::setAppLabel(const QString &appLabel)
-{
-  if (m_appLabel != appLabel) {
-    m_appLabel = appLabel;
-    emit appLabelChanged();
-  }
-}
-
-QString QuickEmbeddedShellView::appIcon() const
-{
-  return m_appIcon;
-}
-
-void QuickEmbeddedShellView::setAppIcon(const QString &appIcon)
-{
-  if (m_appIcon != appIcon) {
-    m_appIcon = appIcon;
-    emit appIconChanged();
-  }
+  return m_view;
 }
 
 QString QuickEmbeddedShellView::label() const
@@ -161,4 +121,47 @@ void QuickEmbeddedShellView::setCustomData(const QVariant &customData)
     m_customData = customData;
     emit customDataChanged();
   }
+}
+
+QuickEmbeddedShellView *QuickEmbeddedShellView::parentView() const
+{
+  return m_parentView;
+}
+
+void QuickEmbeddedShellView::setParentView(QuickEmbeddedShellView *parentView)
+{
+  if (!m_parentView && parentView) {
+    m_parentView = parentView;
+    emit parentViewChanged();
+  }
+}
+
+void QuickEmbeddedShellView::createView()
+{
+  EmbeddedShellSurfaceView *parentView = nullptr;
+
+  if (m_parentView)
+  {
+    parentView = m_parentView->view();
+    if (!parentView)
+    {
+      connect(m_parentView, &QuickEmbeddedShellView::viewChanged, this, &QuickEmbeddedShellView::createView, Qt::SingleShotConnection);
+      return;
+    }
+  }
+
+  m_view = m_surface->createView(m_label, m_icon, m_sortIndex, m_customData, parentView);
+  Q_ASSERT(m_view);
+
+  connect(m_view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::updateSelected);
+  connect(m_view, &EmbeddedShellSurfaceView::topLevelChanged, this, &QuickEmbeddedShellView::updateTopLevel);
+  connect(this, &QuickEmbeddedShellView::labelChanged, m_view, [this]() { m_view->setLabel(label()); });
+  connect(this, &QuickEmbeddedShellView::iconChanged, m_view, [this]() { m_view->setIcon(icon()); });
+  connect(this, &QuickEmbeddedShellView::sortIndexChanged, m_view, [this]() { m_view->setSortIndex(sortIndex()); });
+  connect(this, &QuickEmbeddedShellView::customDataChanged, m_view, [this]() { m_view->setCustomData(customData()); });
+  connect(this, &QuickEmbeddedShellView::select, m_view, &EmbeddedShellSurfaceView::select);
+  connect(this, &QObject::destroyed, m_view, &QObject::deleteLater);
+
+  m_completed = true;
+  emit viewChanged();
 }

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -33,9 +33,17 @@ QuickEmbeddedShellSurface *QuickEmbeddedShellView::surface() const
 
 void QuickEmbeddedShellView::setSurface(QuickEmbeddedShellSurface *surface)
 {
-  if (!m_surface && surface) {
+  if (m_surface == surface) {
+    return;
+  }
+
+  if (!m_completed) {
     m_surface = surface;
     emit surfaceChanged();
+  }
+  else
+  {
+    qWarning() << "surface cannot be changed from" << m_surface << "to" << surface << ":" << m_completed;
   }
 }
 
@@ -110,6 +118,28 @@ void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
   }
 }
 
+QString QuickEmbeddedShellView::persistentId() const
+{
+  return m_persistentId;
+}
+
+void QuickEmbeddedShellView::setPersistentId(const QString &persistentId)
+{
+  if (m_persistentId == persistentId) {
+    return;
+  }
+
+  if (!m_completed)
+  {
+    m_persistentId = persistentId;
+    emit persistentIdChanged();
+  }
+  else
+  {
+    qWarning() << "persistentId cannot be changed from" << m_persistentId << "to" << persistentId << ":" << m_completed;
+  }
+}
+
 QVariantMap QuickEmbeddedShellView::customData() const
 {
   return m_customData;
@@ -130,9 +160,18 @@ QuickEmbeddedShellView *QuickEmbeddedShellView::parentView() const
 
 void QuickEmbeddedShellView::setParentView(QuickEmbeddedShellView *parentView)
 {
-  if (!m_parentView && parentView) {
+  if (m_parentView == parentView) {
+    return;
+  }
+
+  if (!m_completed)
+  {
     m_parentView = parentView;
     emit parentViewChanged();
+  }
+  else
+  {
+    qWarning() << "parentView cannot be changed from" << m_parentView << "to" << parentView << ":" << m_completed;
   }
 }
 
@@ -150,7 +189,12 @@ void QuickEmbeddedShellView::createView()
     }
   }
 
-  m_view = m_surface->createView(m_label, m_icon, m_sortIndex, m_customData, parentView);
+  m_view = m_surface->createView(m_label,
+                                 m_icon,
+                                 m_sortIndex,
+                                 m_persistentId,
+                                 m_customData,
+                                 parentView);
   Q_ASSERT(m_view);
 
   connect(m_view, &EmbeddedShellSurfaceView::selectedChanged, this, &QuickEmbeddedShellView::updateSelected);

--- a/quickembeddedshellwindow/quickembeddedshellview.cpp
+++ b/quickembeddedshellwindow/quickembeddedshellview.cpp
@@ -110,12 +110,12 @@ void QuickEmbeddedShellView::setSortIndex(quint32 sortIndex)
   }
 }
 
-QVariant QuickEmbeddedShellView::customData() const
+QVariantMap QuickEmbeddedShellView::customData() const
 {
   return m_customData;
 }
 
-void QuickEmbeddedShellView::setCustomData(const QVariant &customData)
+void QuickEmbeddedShellView::setCustomData(const QVariantMap &customData)
 {
   if (m_customData != customData) {
     m_customData = customData;

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -54,16 +54,18 @@ public:
   QVariant customData() const;
   void setCustomData(const QVariant &customData);
 
+
 signals:
-  void surfaceChanged(QuickEmbeddedShellSurface *surface);
-  void selectedChanged(bool selected);
-  void appIdChanged(const QString &appId);
-  void appLabelChanged(const QString &appLabel);
-  void appIconChanged(const QString &appIcon);
-  void labelChanged(const QString &label);
-  void iconChanged(const QString &icon);
-  void sortIndexChanged(quint32 sortIndex);
-  void customDataChanged(const QVariant &customData);
+  void select();
+  void surfaceChanged();
+  void selectedChanged();
+  void appIdChanged();
+  void appLabelChanged();
+  void appIconChanged();
+  void labelChanged();
+  void iconChanged();
+  void sortIndexChanged();
+  void customDataChanged();
 
 private:
   void setSelected(bool selected);

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -20,6 +20,7 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QString persistentId READ persistentId WRITE setPersistentId NOTIFY persistentIdChanged)
   Q_PROPERTY(QVariantMap customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(QuickEmbeddedShellView *parentView READ parentView WRITE setParentView NOTIFY parentViewChanged)
 
@@ -46,6 +47,9 @@ public:
   quint32 sortIndex() const;
   void setSortIndex(quint32 sortIndex);
 
+  QString persistentId() const;
+  void setPersistentId(const QString &persistentId);
+
   QVariantMap customData() const;
   void setCustomData(const QVariantMap &customData);
 
@@ -59,6 +63,7 @@ signals:
   void topLevelChanged();
   void viewChanged();
   void parentViewChanged();
+  void persistentIdChanged();
   void labelChanged();
   void iconChanged();
   void sortIndexChanged();
@@ -75,6 +80,7 @@ private:
 
   EmbeddedShellSurfaceView *m_view;
   QuickEmbeddedShellView *m_parentView;
+  QString m_persistentId;
   QString m_label;
   QString m_icon;
   quint32 m_sortIndex;

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -14,14 +14,14 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
 
   Q_PROPERTY(QuickEmbeddedShellSurface *surface READ surface WRITE setSurface NOTIFY surfaceChanged)
   Q_PROPERTY(bool selected READ selected NOTIFY selectedChanged)
+  Q_PROPERTY(bool topLevel READ topLevel NOTIFY topLevelChanged)
 
-  Q_PROPERTY(QString appId READ appId WRITE setAppId NOTIFY appIdChanged)
-  Q_PROPERTY(QString appLabel READ appLabel WRITE setAppLabel NOTIFY appLabelChanged)
-  Q_PROPERTY(QString appIcon READ appIcon WRITE setAppIcon NOTIFY appIconChanged)
+  Q_PROPERTY(EmbeddedShellSurfaceView *view READ view NOTIFY viewChanged)
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
   Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
+  Q_PROPERTY(QuickEmbeddedShellView *parentView READ parentView WRITE setParentView NOTIFY parentViewChanged)
 
 public:
   explicit QuickEmbeddedShellView(QQuickItem *parent = nullptr);
@@ -33,14 +33,9 @@ public:
 
   bool selected() const;
 
-  QString appId() const;
-  void setAppId(const QString &appId);
+  bool topLevel() const;
 
-  QString appLabel() const;
-  void setAppLabel(const QString &appLabel);
-
-  QString appIcon() const;
-  void setAppIcon(const QString &appIcon);
+  EmbeddedShellSurfaceView *view() const;
 
   QString label() const;
   void setLabel(const QString &label);
@@ -54,29 +49,32 @@ public:
   QVariant customData() const;
   void setCustomData(const QVariant &customData);
 
+  QuickEmbeddedShellView *parentView() const;
+  void setParentView(QuickEmbeddedShellView *parentView);
 
 signals:
   void select();
   void surfaceChanged();
   void selectedChanged();
-  void appIdChanged();
-  void appLabelChanged();
-  void appIconChanged();
+  void topLevelChanged();
+  void viewChanged();
+  void parentViewChanged();
   void labelChanged();
   void iconChanged();
   void sortIndexChanged();
   void customDataChanged();
 
 private:
-  void setSelected(bool selected);
+  void updateSelected(bool selected);
+  void updateTopLevel(bool topLevel);
   void createView();
 
   QuickEmbeddedShellSurface *m_surface;
   bool m_selected;
+  bool m_topLevel;
 
-  QString m_appId;
-  QString m_appLabel;
-  QString m_appIcon;
+  EmbeddedShellSurfaceView *m_view;
+  QuickEmbeddedShellView *m_parentView;
   QString m_label;
   QString m_icon;
   quint32 m_sortIndex;

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -20,7 +20,7 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
-  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
+  Q_PROPERTY(QVariantMap customData READ customData WRITE setCustomData NOTIFY customDataChanged)
   Q_PROPERTY(QuickEmbeddedShellView *parentView READ parentView WRITE setParentView NOTIFY parentViewChanged)
 
 public:
@@ -46,8 +46,8 @@ public:
   quint32 sortIndex() const;
   void setSortIndex(quint32 sortIndex);
 
-  QVariant customData() const;
-  void setCustomData(const QVariant &customData);
+  QVariantMap customData() const;
+  void setCustomData(const QVariantMap &customData);
 
   QuickEmbeddedShellView *parentView() const;
   void setParentView(QuickEmbeddedShellView *parentView);
@@ -78,6 +78,6 @@ private:
   QString m_label;
   QString m_icon;
   quint32 m_sortIndex;
-  QVariant m_customData;
+  QVariantMap m_customData;
   bool m_completed;
 };

--- a/quickembeddedshellwindow/quickembeddedshellview.h
+++ b/quickembeddedshellwindow/quickembeddedshellview.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef QUICKEMBEDDEDSHELLVIEW_H
-#define QUICKEMBEDDEDSHELLVIEW_H
+#pragma once
 
 #include "quickembeddedshellsurface.h"
 #include "quickembeddedshellwindow_global.h"
@@ -22,6 +21,7 @@ class EMBEDDEDSHELLWINDOW_EXPORT QuickEmbeddedShellView : public QQuickItem
   Q_PROPERTY(QString label READ label WRITE setLabel NOTIFY labelChanged)
   Q_PROPERTY(QString icon READ icon WRITE setIcon NOTIFY iconChanged)
   Q_PROPERTY(quint32 sortIndex READ sortIndex WRITE setSortIndex NOTIFY sortIndexChanged)
+  Q_PROPERTY(QVariant customData READ customData WRITE setCustomData NOTIFY customDataChanged)
 
 public:
   explicit QuickEmbeddedShellView(QQuickItem *parent = nullptr);
@@ -51,6 +51,9 @@ public:
   quint32 sortIndex() const;
   void setSortIndex(quint32 sortIndex);
 
+  QVariant customData() const;
+  void setCustomData(const QVariant &customData);
+
 signals:
   void surfaceChanged(QuickEmbeddedShellSurface *surface);
   void selectedChanged(bool selected);
@@ -60,6 +63,7 @@ signals:
   void labelChanged(const QString &label);
   void iconChanged(const QString &icon);
   void sortIndexChanged(quint32 sortIndex);
+  void customDataChanged(const QVariant &customData);
 
 private:
   void setSelected(bool selected);
@@ -74,7 +78,6 @@ private:
   QString m_label;
   QString m_icon;
   quint32 m_sortIndex;
+  QVariant m_customData;
   bool m_completed;
 };
-
-#endif // QUICKEMBEDDEDSHELLVIEW_H

--- a/quickembeddedshellwindow/quickembeddedshellwindow.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef QUICKEMBEDDEDSHELLWINDOW_H
-#define QUICKEMBEDDEDSHELLWINDOW_H
+#pragma once
 
 #include "embeddedplatform.h"
 #include "quickembeddedshellsurface.h"
@@ -39,5 +38,3 @@ public:
 private:
   QuickEmbeddedShellSurface m_surface;
 };
-
-#endif // QUICKEMBEDDEDSHELLWINDOW_H

--- a/quickembeddedshellwindow/quickembeddedshellwindow_global.h
+++ b/quickembeddedshellwindow/quickembeddedshellwindow_global.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLWINDOW_GLOBAL_H
-#define EMBEDDEDSHELLWINDOW_GLOBAL_H
+#pragma once
 
 #include <QtCore/qglobal.h>
 
@@ -10,5 +9,3 @@
 #else
 #  define EMBEDDEDSHELLWINDOW_EXPORT Q_DECL_IMPORT
 #endif
-
-#endif // EMBEDDEDSHELLWINDOW_GLOBAL_H

--- a/quickembeddedshellwindow/waylandinputregion.cpp
+++ b/quickembeddedshellwindow/waylandinputregion.cpp
@@ -26,7 +26,7 @@ void WaylandInputRegion::setActive(bool active)
     if (isComponentComplete()) {
         updateRegion();
     }
-    Q_EMIT activeChanged(active);
+    emit activeChanged(active);
 }
 
 void WaylandInputRegion::itemChange(ItemChange c, const ItemChangeData& d) {
@@ -40,7 +40,7 @@ void WaylandInputRegion::geometryChange(const QRectF &newGeometry,
     updateRegion();
 }
 
-void WaylandInputRegion::SetImage(QVariant image, QRect sceneRect)
+void WaylandInputRegion::setImage(QVariant image, QRect sceneRect)
 {
   auto img = image.value<QImage>();
   img = img.createAlphaMask(Qt::AvoidDither);
@@ -77,7 +77,7 @@ void WaylandInputRegion::updateRegion() {
 
   auto result = grabToImage(aligned.size());
   connect(result.data(), &QQuickItemGrabResult::ready, this, [=](){
-      this->SetImage(result->image(), aligned);
+      this->setImage(result->image(), aligned);
       // QSharedPointer captured into this lambda remains alive indefinitely.
       // Disconnect, to dispose of the lambda and subsequently the object held by the shared pointer.
       disconnect(result.data(), &QQuickItemGrabResult::ready, this, nullptr);
@@ -88,4 +88,11 @@ void WaylandInputRegion::componentComplete()
 {
   updateRegion();
   QQuickItem::componentComplete();
+}
+
+void WaylandInputRegion::setPixelMask(bool newMask) {
+  if (m_pixelMask == newMask)
+    return;
+  m_pixelMask = newMask;
+  emit pixelMaskChanged(m_pixelMask);
 }

--- a/quickembeddedshellwindow/waylandinputregion.h
+++ b/quickembeddedshellwindow/waylandinputregion.h
@@ -1,5 +1,6 @@
-#ifndef WAYLANDINPUTREGION_H
-#define WAYLANDINPUTREGION_H
+// SPDX-License-Identifier: LGPL-3.0-only
+
+#pragma once
 
 #include <QQuickItem>
 #include <QVariant>
@@ -14,51 +15,44 @@ Currently only one InputRegion Item per window is supported.
 
 class WaylandInputRegion : public QQuickItem
 {
-    Q_OBJECT
-    QML_ELEMENT
+  Q_OBJECT
+  QML_ELEMENT
 
 public:
-    explicit WaylandInputRegion(QQuickItem *parent = nullptr);
-    Q_PROPERTY(bool pixelMask READ pixelMask WRITE setPixelMask NOTIFY pixelMaskChanged)
-    /**
+  explicit WaylandInputRegion(QQuickItem *parent = nullptr);
+  Q_PROPERTY(bool pixelMask READ pixelMask WRITE setPixelMask NOTIFY pixelMaskChanged)
+  /**
      * @brief Whether masking is active
      *
      * When set to false, the window mask is reset.
      * Default is true.
      */
-    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
+  Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
 
 protected:
-    void itemChange(ItemChange, const ItemChangeData &) override;
-    void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
-
-public slots:
-    void SetImage(QVariant image, QRect position);
-    void updateRegion();
+  void itemChange(ItemChange, const ItemChangeData &) override;
+  void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 
 public:
-    void componentComplete() override;
-    QQuickItem *item() const;
-    void setItem(QQuickItem *newItem);
-    bool pixelMask() const { return m_pixelMask; }
+  void setImage(QVariant image, QRect position);
+  void updateRegion();
 
-    void setPixelMask(bool newMask) {
-        if (m_pixelMask == newMask)
-            return;
-        m_pixelMask = newMask;
-        emit pixelMaskChanged(m_pixelMask);
-    }
+public:
+  void componentComplete() override;
+  QQuickItem *item() const;
+  void setItem(QQuickItem *newItem);
 
-    bool active() const;
-    void setActive(bool active);
-    Q_SIGNAL void activeChanged(bool active);
+  bool pixelMask() const { return m_pixelMask; }
+  void setPixelMask(bool newMask);
+
+  bool active() const;
+  void setActive(bool active);
 
 signals:
-    void pixelMaskChanged(bool mask);
+  void pixelMaskChanged(bool mask);
+  void activeChanged(bool active);
 
 private:
-    bool m_pixelMask = false;
-    bool m_active = true;
+  bool m_pixelMask = false;
+  bool m_active = true;
 };
-
-#endif // WAYLANDINPUTREGION_H

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -62,37 +62,14 @@ EmbeddedShellIntegration::createShellSurface(
 
   uint32_t sort_index = 0;
 
-  auto env_sort_index = qgetenv("EMBEDDED_SHELL_SORT_INDEX");
-  if (!env_sort_index.isNull()) {
-    bool ok = false;
-    sort_index = env_sort_index.toUInt(&ok);
-    if (!ok) {
-      qWarning() << "failed to read sort index from EMBEDDED_SORT_INDEX:"
-                 << env_sort_index << "is not an integer";
-    }
-  }
-
   prop = window->window()->property("sortIndex");
   if (prop.isValid())
     sort_index = prop.toUInt();
 
-  auto ess = m_shell->createSurface(window, anchor, margin, sort_index);
+  auto ess = m_shell->createSurface(window, anchor, margin);
 
   if (ess == nullptr) {
     return nullptr;
-  }
-
-  const QString appId = qEnvironmentVariable("EMBEDDED_SHELL_APP_ID");
-  if (!appId.isEmpty()) {
-    ess->setAppId(appId);
-  }
-  const QString appLabel = qEnvironmentVariable("EMBEDDED_SHELL_APP_LABEL");
-  if (!appLabel.isEmpty()) {
-    ess->setAppLabel(appLabel);
-  }
-  const QString appIcon = qEnvironmentVariable("EMBEDDED_SHELL_APP_ICON");
-  if (!appIcon.isEmpty()) {
-    ess->setAppIcon(appIcon);
   }
 
   m_windows.insert(window, ess);

--- a/shellintegration/embeddedshellintegration.cpp
+++ b/shellintegration/embeddedshellintegration.cpp
@@ -84,15 +84,15 @@ EmbeddedShellIntegration::createShellSurface(
 
   const QString appId = qEnvironmentVariable("EMBEDDED_SHELL_APP_ID");
   if (!appId.isEmpty()) {
-    ess->sendAppId(appId);
+    ess->setAppId(appId);
   }
   const QString appLabel = qEnvironmentVariable("EMBEDDED_SHELL_APP_LABEL");
   if (!appLabel.isEmpty()) {
-    ess->sendAppLabel(appLabel);
+    ess->setAppLabel(appLabel);
   }
   const QString appIcon = qEnvironmentVariable("EMBEDDED_SHELL_APP_ICON");
   if (!appIcon.isEmpty()) {
-    ess->sendAppIcon(appIcon);
+    ess->setAppIcon(appIcon);
   }
 
   m_windows.insert(window, ess);
@@ -109,7 +109,7 @@ EmbeddedShellIntegration::nativeResourceForWindow(const QByteArray &resource,
     if (found != m_windows.end()) {
       return found.value();
     }
-    qDebug() << __PRETTY_FUNCTION__ << " ... not found";
+    qDebug() << Q_FUNC_INFO << " ... not found";
     return nullptr;
   }
   return QWaylandShellIntegration::nativeResourceForWindow(resource, window);

--- a/shellintegration/embeddedshellintegration.h
+++ b/shellintegration/embeddedshellintegration.h
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
-#ifndef EMBEDDEDSHELLINTEGRATION_H
-#define EMBEDDEDSHELLINTEGRATION_H
+#pragma once
 
 #include <QScopedPointer>
 #include <QtWaylandClient/private/qwaylandshellintegration_p.h>
@@ -33,5 +32,3 @@ private:
   QScopedPointer<EmbeddedShell> m_shell;
   QMap<QtWaylandClient::QWaylandWindow *, EmbeddedShellSurface *> m_windows;
 };
-
-#endif // EMBEDDEDSHELLINTEGRATION_H


### PR DESCRIPTION
EmbeddedShellSurface and EmbeddedShellSurfaceView (plus their qml counterparts) get a new customData property which can hold QVariant based data. The internal data type needs to be serializable (QDataStream) in order to work with the underlying wayland protocol.

This allows to transmit data from the client to the server if needed. Since the data needs to be serialized, it is intended for smaller data that does not change often.

Migrated ifdefs to pragma once.

Added missing license information to header files that were missing it.

Qtifying code (getters without get*, set* instead of send*, removing slots where not needed, mainstreaming macro usage).

Adding Q_PROPERTIES to EmbeddedShellSurface to be in line with EmbeddedShellSurfaceView.