### PR TITLE
Add option to set socketName property via environment variable

### DIFF
--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -10,6 +10,10 @@
 #include <QtGui/QGuiApplication>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
+#include <qlogging.h>
+#include <qobject.h>
+#include <qtenvironmentvariables.h>
+#include <qvariant.h>
 #include <sortfilterproxymodel.h>
 #include "ScreenShotDBusInterface.hpp"
 #include "TaskSwitcherDBusInterface.hpp"
@@ -64,6 +68,17 @@ int main(int argc, char *argv[]) {
                                         "SortFilterProxyModel");
 
   QQmlApplicationEngine appEngine;
+
+  QString socketName = qEnvironmentVariable("EMBEDDED_COMPOSITOR_SOCKET_NAME");
+
+  if(!socketName.isEmpty()) {
+    qInfo() << "Setting socket name to " << socketName;
+
+    appEngine.setInitialProperties({
+      {"socketName", QVariant::fromValue(socketName)}
+    });
+  }
+  
   ScreenShotDBusInterface screenShot(&appEngine);
 
   bool exitOnQmlWarning = qgetenv("QML_WARNING_EXIT") == "1";

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -7,13 +7,12 @@
 #include <QDBusMetaType>
 #include <QtCore/QDebug>
 #include <QtCore/QUrl>
+#include <QtCore/qtenvironmentvariables.h>
 #include <QtGui/QGuiApplication>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQml/QQmlContext>
-#include <qlogging.h>
-#include <qobject.h>
-#include <qtenvironmentvariables.h>
-#include <qvariant.h>
+#include <QObject>
+#include <QVariant>
 #include <sortfilterproxymodel.h>
 #include "ScreenShotDBusInterface.hpp"
 #include "TaskSwitcherDBusInterface.hpp"

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -71,8 +71,8 @@ int main(int argc, char *argv[]) {
 
   QString socketName = qEnvironmentVariable("EMBEDDED_COMPOSITOR_SOCKET_NAME");
 
-  if(!socketName.isEmpty()) {
-    qInfo() << "Setting socket name to " << socketName;
+  if (!socketName.isEmpty()) {
+    qInfo() << "Setting socket name to" << socketName;
 
     appEngine.setInitialProperties({
       {"socketName", QVariant::fromValue(socketName)}

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -78,7 +78,7 @@ int main(int argc, char *argv[]) {
       {"socketName", QVariant::fromValue(socketName)}
     });
   }
-  
+
   ScreenShotDBusInterface screenShot(&appEngine);
 
   bool exitOnQmlWarning = qgetenv("QML_WARNING_EXIT") == "1";

--- a/embedded-compositor/main.cpp
+++ b/embedded-compositor/main.cpp
@@ -75,7 +75,7 @@ int main(int argc, char *argv[]) {
     qInfo() << "Setting socket name to" << socketName;
 
     appEngine.setInitialProperties({
-      {"socketName", QVariant::fromValue(socketName)}
+      {"socketName", socketName}
     });
   }
 


### PR DESCRIPTION
This branch adds the `EMBEDDED_COMPOSITOR_SOCKET_NAME` environment variable to specify the name of the Wayland socket, which the `QWaylandCompositor` creates to communicate with its clients. 