### PR TITLE
Adding fix for incorrect value of QInputMethod::keyboardRectangle on …

### DIFF
--- a/embedded-compositor/qml/main.qml
+++ b/embedded-compositor/qml/main.qml
@@ -431,6 +431,14 @@ WaylandCompositor {
                 }
 
                 shellSurface.sendConfigure(Qt.size(newWidth, newHeight));
+
+                if (keyboardLoader.item && shellSurfaceItem.activeFocus) {
+                    // Note: This forces a reevaluation of Qt.inputMethod.keyboardRectangle on the client side.
+                    // Without resetting the activeFocus, the new window size isn't taken into account and
+                    // keyboardRectangle will have an incorrect value for the client.
+                    rootTransformItem.forceActiveFocus()
+                    shellSurfaceItem.forceActiveFocus()
+                }
             }
         }
     }


### PR DESCRIPTION
…wayland clients after their surfaces have been resized.

It looks like a surface resize does not force a reevaluation of Qt.inputMethod.keyboardRectangle on the client side when client windows change their sizes. Even if the keyboard on the compositor changes its size, the keyboardRectangle will still use incorrect screen dimensions as a basis in these cases and deliver incorrect dimensions. As a workaround, the active focus within the wayland compositor if briefly changed to another element and immediately restored, which will update the keyboardRectangle properly.